### PR TITLE
Use builtin actions for moving to the next/previous slide

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -6,8 +6,8 @@ Module for using ProPresenter with the Elgato Stream Deck and Companion
 ## Slides
 Command | Description
 ------- | -----------
-Next Slide | Advances to the next slide in the current document
-Last Slide | Moves to the previous slide in the current document
+Next Slide | Advances to the next slide in the current document. If at the end of a document, will advance to the start of the next document in the playlist.
+Previous Slide | Moves to the previous slide in the current document. If at the start of a document, will move to the start of the previous document in the playlist.
 Jump to Slide | Moves to the slide number
 
 ## Clear/Logo
@@ -29,5 +29,5 @@ Stage Display Layout | Sets the stage display layout. Index is a 0-based number 
 
 ----
 
-ALL COMMANDS ONLY WORK IN THE SAME DOCUMENT, NOT ON CONTIGUOUS PLAYLISTS  
+
 FOR BEST PERFORMANCE ADD DOCUMENT TO PLAYLIST (propresenter like to dump loads of info down the connection if you use it directly from the library)

--- a/index.js
+++ b/index.js
@@ -215,12 +215,10 @@ instance.prototype.action = function(action) {
 	switch (action.action) {
 
 		case 'next':
-			var nextSlide = parseInt(self.slideIndex) + 1
 			cmd = '{"action":"presentationTriggerNext"}';
 			break;
 
 		case 'last':
-			var nextSlide = parseInt(self.slideIndex) + -1
 			cmd = '{"action":"presentationTriggerPrevious"}';
 			break;
 

--- a/index.js
+++ b/index.js
@@ -131,11 +131,6 @@ instance.prototype.init_ws = function() {
 			debug("Connected");
 		})
 
-		self.socket.on('message', function incoming(data) {
-			var slideData = JSON.parse(data)
-			self.slideIndex = slideData.slideIndex
-		})
-
 	}
 };
 
@@ -165,7 +160,7 @@ instance.prototype.actions = function(system) {
 
 	self.system.emit('instance_actions', self.id, {
 		'next': { label: 'Next Slide' },
-		'last': { label: 'Last Slide' },
+		'last': { label: 'Previous Slide' },
 		'slideNumber': {
 			label: 'Specific Slide',
 			options: [
@@ -221,12 +216,12 @@ instance.prototype.action = function(action) {
 
 		case 'next':
 			var nextSlide = parseInt(self.slideIndex) + 1
-			cmd = '{"action":"presentationTriggerIndex","slideIndex":'+nextSlide+',"presentationPath":" "}'
+			cmd = '{"action":"presentationTriggerNext"}';
 			break;
 
 		case 'last':
 			var nextSlide = parseInt(self.slideIndex) + -1
-			cmd = '{"action":"presentationTriggerIndex","slideIndex":'+nextSlide+',"presentationPath":" "}'
+			cmd = '{"action":"presentationTriggerPrevious"}';
 			break;
 
 		case 'slideNumber':


### PR DESCRIPTION
ProPresenter supports native actions for moving to the next/previous slide in a document. This PR replaces the existing last/next actions with new ones.

This has several advantages:
1. We don't need to keep track of the current `slideIndex` and add or subtract from it.
2. Triggering the action repeatedly is faster because we don't need to first wait for ProPresenter to transition the slide and respond with the new `slideIndex`.
3. We can also move to the next/previous document in a playlist if we try to move beyond the slides in the current document.

The PR also removes the `self.socket.on('message')` listener since it's no longer needed.