### PR TITLE
Dynamic variables, Pro6 Windows support, and improved websockets

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -27,6 +27,16 @@ Stage Display Message | Shows the message on the stage display output
 Stage Display Hide Message | Removes the stage display message
 Stage Display Layout | Sets the stage display layout. Index is a 0-based number (in the order shown in ProPresenter)
 
+
+# Dynamic Variables
+Variable | Description
+-------- | -----------
+$(propresenter:current_slide) | The number of the active slide (>= 1), or "N/A" if unknown.
+$(propresenter:total_slides)  | The total number of slides in the current document, or "N/A" if unknown.
+$(propresenter:presentation_name) | The name of the current presentation, or "N/A" if unknown.
+$(propresenter:connection_status) | The current connection status to ProPresenter ("Disconnected", "Connected", etc.).
+
+
 ----
 
 

--- a/HELP.md
+++ b/HELP.md
@@ -34,7 +34,7 @@ Variable | Description
 $(propresenter:current_slide) | The number of the active slide (>= 1), or "N/A" if unknown.
 $(propresenter:total_slides)  | The total number of slides in the current document, or "N/A" if unknown.
 $(propresenter:presentation_name) | The name of the current presentation, or "N/A" if unknown.
-$(propresenter:connection_status) | The current connection status to ProPresenter ("Disconnected", "Connected", etc.).
+$(propresenter:connection_status) | The current connection status to ProPresenter ("Disconnected" or "Connected").
 
 
 ----

--- a/index.js
+++ b/index.js
@@ -486,7 +486,6 @@ instance.prototype.onWebSocketMessage = function(message) {
 
 	if(objData.presentationPath !== undefined && objData.presentationPath !== self.currentState.presentationPath) {
 		// The presenationPath has changed. Update the path and request the information.
-		self.currentState.presentationPath = objData.presentationPath;
 		self.getProPresenterState();
 	}
 

--- a/index.js
+++ b/index.js
@@ -188,7 +188,7 @@ instance.prototype.startConnectionTimer = function() {
 
 
 /**
- * Stops the recinnection timer.
+ * Stops the reconnection timer.
  */
 instance.prototype.stopConnectionTimer = function() {
 	var self = this;
@@ -202,7 +202,7 @@ instance.prototype.stopConnectionTimer = function() {
 
 
 /**
- * Updates the cinnection status variable.
+ * Updates the connection status variable.
  */
 instance.prototype.setConnectionVariable = function(status, updateLog) {
 	var self = this;
@@ -485,7 +485,7 @@ instance.prototype.onWebSocketMessage = function(message) {
 	}
 
 	if(objData.presentationPath !== undefined && objData.presentationPath !== self.currentState.presentationPath) {
-		// The presenationPath has changed. Update the path and request the information.
+		// The presentationPath has changed. Update the path and request the information.
 		self.getProPresenterState();
 	}
 

--- a/index.js
+++ b/index.js
@@ -368,8 +368,13 @@ instance.prototype.action = function(action) {
 			break;
 
 		case 'slideNumber':
-			var nextIndex = parseInt(opt.slide)-1
-			cmd = '{"action":"presentationTriggerIndex","slideIndex":'+nextIndex+',"presentationPath":" "}';
+			var nextIndex = parseInt(opt.slide)-1;
+			cmd = JSON.stringify({
+				action: "presentationTriggerIndex",
+				slideIndex: nextIndex,
+				// Pro 6 for Windows requires 'presentationPath' to be set.
+				presentationPath: self.currentState.presentationPath
+			});
 			break;
 
 		case 'clearall':
@@ -471,7 +476,11 @@ instance.prototype.onWebSocketMessage = function(message) {
 		case 'presentationCurrent':
 			var objPresentation = objData.presentation;
 			self.currentState.presentationName = objPresentation.presentationName;
-			self.currentState.presentationPath = objPresentation.presentationCurrentLocation;
+
+			// '.presentationPath' and '.presentation.presentationCurrentLocation' look to be
+			//	the same on Pro6 Mac, but '.presentation.presentationCurrentLocation' is the
+			//	wrong value on Pro6 PC (tested 6.1.6.2). Use '.presentationPath' instead. 
+			self.currentState.presentationPath = objData.presentationPath;
 
 			// Get the total number of slides in this presentation
 			var totalSlides = 0;

--- a/index.js
+++ b/index.js
@@ -128,19 +128,19 @@ instance.prototype.initVariables = function() {
 	var variables = [
 		{
 			label: 'Current slide number',
-			name:  'currentSlide'
+			name:  'current_slide'
 		},
 		{
 			label: 'Total slides in presentation',
-			name:  'totalSlides'
+			name:  'total_slides'
 		},
 		{
 			label: 'Presentation name',
-			name:  'presentationName'
+			name:  'presentation_name'
 		},
 		{
 			label: 'Connection status',
-			name:  'connectionStatus'
+			name:  'connection_status'
 		}
 	];
 
@@ -158,10 +158,10 @@ instance.prototype.initVariables = function() {
  */
 instance.prototype.updateVariables = function() {
 	var self = this;
-	self.setVariable('currentSlide', self.currentState.currentSlide);
-	self.setVariable('presentationName', self.currentState.presentationName);
-	self.setVariable('totalSlides', self.currentState.totalSlides);
-	self.setVariable('connectionStatus', self.currentState.connectionStatus);
+	self.setVariable('current_slide', self.currentState.currentSlide);
+	self.setVariable('presentation_name', self.currentState.presentationName);
+	self.setVariable('total_slides', self.currentState.totalSlides);
+	self.setVariable('connection_status', self.currentState.connectionStatus);
 };
 
 

--- a/index.js
+++ b/index.js
@@ -74,11 +74,6 @@ instance.prototype.destroy = function() {
 		delete self.socket;
 	}
 
-	if (self.indexTimer !== undefined) {
-		clearInterval(self.indexTimer);
-		delete self.indexTimer;
-	}
-
 	if (self.reconTimer !== undefined) {
 		clearInterval(self.reconTimer);
 		delete self.reconTimer;
@@ -107,17 +102,15 @@ instance.prototype.init_ws = function() {
 		self.reconTimer = setInterval(self.recon.bind(self), 5000)
 
 		self.socket.on('open', function open() {
-			self.socket.send('{"pwd":'+self.config.pass+',"ptl":610,"acn":"ath"}')
+			self.socket.send(JSON.stringify({
+				password: self.config.pass,
+				protocol: "610",
+				action: "authenticate"
+			}));
 			self.status(self.STATE_OK);
 
 			debug(" WS STATE: " +self.socket.readyState)
 
-			if (self.indexTimer !== undefined) {
-				clearInterval(self.indexTimer);
-				delete self.indexTimer;
-			}
-
-			self.indexTimer = setInterval(self.index.bind(self), 250)
 		});
 
 		self.socket.on('error', function (err) {
@@ -129,23 +122,14 @@ instance.prototype.init_ws = function() {
 		self.socket.on('connect', function () {
 			self.status(self.STATE_OK);
 			debug("Connected");
+		});
+
+		self.socket.on('message', function (message) {
+			console.log(message);
 		})
 
 	}
 };
-
-instance.prototype.index = function(){
-	var self = this;
-	if (self.currentStatus !== self.STATE_ERROR) {
-		try {
-			self.socket.send('{"action":"presentationSlideIndex"}');
-		}
-		catch (e) {
-			debug("NETWORK " + e)
-			self.status(self.STATE_ERROR, e);
-		}
-	}
-}
 
 instance.prototype.recon = function(){
 	var self = this;

--- a/index.js
+++ b/index.js
@@ -114,6 +114,10 @@ instance.prototype.destroy = function() {
 instance.prototype.emptyCurrentState = function() {
 	var self = this;
 
+	// Reinitialize the currentState variable, otherwise this variable (and the module's
+	//	state) will be shared between multiple instances of this module.
+	self.currentState = {};
+
 	// The internal state of the connection to ProPresenter
 	self.currentState.internal = {
 		wsConnected: false,

--- a/index.js
+++ b/index.js
@@ -495,7 +495,10 @@ instance.prototype.onWebSocketMessage = function(message) {
 
 		case 'presentationCurrent':
 			var objPresentation = objData.presentation;
-			this.updateVariable('presentation_name', objPresentation.presentationName);
+
+			// Pro6 PC's 'presentationName' contains the raw file extension '.pro6'. Remove it.
+			var presentationName = objPresentation.presentationName.replace('.pro6', '');
+			this.updateVariable('presentation_name', presentationName);
 
 			// '.presentationPath' and '.presentation.presentationCurrentLocation' look to be
 			//	the same on Pro6 Mac, but '.presentation.presentationCurrentLocation' is the

--- a/index.js
+++ b/index.js
@@ -497,7 +497,7 @@ instance.prototype.onWebSocketMessage = function(message) {
 			var objPresentation = objData.presentation;
 
 			// Pro6 PC's 'presentationName' contains the raw file extension '.pro6'. Remove it.
-			var presentationName = objPresentation.presentationName.replace('.pro6', '');
+			var presentationName = objPresentation.presentationName.replace(/\.pro6$/i, '');
 			this.updateVariable('presentation_name', presentationName);
 
 			// '.presentationPath' and '.presentation.presentationCurrentLocation' look to be


### PR DESCRIPTION
Dynamic Variables support was added: `current_slide`, `total_slides`, `presentation_name`, `connection_status`.
- Updated `HELP.md` to describe them.

Significant work was put into cleaning up the websocket connection/reconnection logic:
- Cleaner handling of connection problems and reconnects.
- Changing the module's config connection settings triggers a reconnect.
- An error message is shown if connection is successful but authentication password is incorrect.
- Updated the authentication request syntax. ProPresenter now responds with its current state in real-time in response to the new syntax.
- `self.indexTimer` was removed because it was querying ProPresenter every 250ms and ProPresenter now feeds us the data automatically when it changes.
- It seems to properly control ProPresenter on Windows now.