### PR TITLE
New Timer and StageDisplay Features

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -82,6 +82,7 @@ If you use a lot of timers with commonly used values for duration, you might lik
 1. *Update CountDown Clock* - Set new duration value of the count-down timer. This new value will be used when the timer is next reset.
 2. *Reset Clock* - Stop the count-down timer if running and reset current value back to duration. You  might like to add a little delay (say 100-300ms) to ensure ProPresenter has time to process previous action.
 3. *Start Clock* - Start the count-down timer running. You might like to add a little delay (say 100-300ms) to ensure ProPresenter has time to process previous action.
+
 Use *relative delays*, to ensure these three action arrive in the correct order (or if you prefer absolute delays, make sure the second action has less delay than the third)
 
 # Dynamic Variables

--- a/HELP.md
+++ b/HELP.md
@@ -64,6 +64,10 @@ Command | Description
 Stage Display Message | Shows the message on the stage display output
 Stage Display Hide Message | Removes the stage display message
 Stage Display Layout | Sets the stage display layout. Index is a 0-based number (in the order shown in ProPresenter)
+Toggle Stage Display Layout | You can use this action to toggle (swap) between two selected stage display layouts. Enter two indexes and when this action is run the stage display layout will toggle back and forth.  If neither of these layouts is active when this action is run, the first will will be selected. 
+
+**Tip: Intuitive stage display toggle.**
+If you regularly use two stage display layouts, you can setup a button with the "Toggle Stage Display Layout" and set it's text title to $(propresenter:current_stage_display_name) so it will always display the active stage display layout and when pressed it will toggle between your two chosen layouts.
 
 ## Clocks (Timers)
 Command | Description
@@ -86,3 +90,6 @@ $(propresenter:current_slide) | The number of the active slide (>= 1), or "N/A" 
 $(propresenter:total_slides)  | The total number of slides in the current document, or "N/A" if unknown.
 $(propresenter:presentation_name) | The name of the current presentation, or "N/A" if unknown.
 $(propresenter:connection_status) | The current connection status to ProPresenter ("Disconnected" or "Connected").
+$(propresenter:watched_clock_current_time) | In the config of this module, you can specify the index of a clock (timer) that you want to monitor. This dynamic variable will be updated once per second to the current value of the clock specified. You could use this to display a live timer value on a button!
+$(propresenter:current_stage_display_index) | Index of the currently selected stage display layout (updated whenever a new layout is selected)
+$(propresenter:current_stage_display_name) | Name of the currently selected stage display layout (updated whenever a new layout is selected)

--- a/HELP.md
+++ b/HELP.md
@@ -82,6 +82,7 @@ If you use a lot of timers with commonly used values for duration, you might lik
 1. *Update CountDown Clock* - Set new duration value of the count-down timer. This new value will be used when the timer is next reset.
 2. *Reset Clock* - Stop the count-down timer if running and reset current value back to duration. You  might like to add a little delay (say 100-300ms) to ensure ProPresenter has time to process previous action.
 3. *Start Clock* - Start the count-down timer running. You might like to add a little delay (say 100-300ms) to ensure ProPresenter has time to process previous action.
+Use *relative delays*, to ensure these three action arrive in the correct order (or if you prefer absolute delays, make sure the second action has less delay than the third)
 
 # Dynamic Variables
 Variable | Description

--- a/HELP.md
+++ b/HELP.md
@@ -64,10 +64,6 @@ Command | Description
 Stage&nbsp;Display&nbsp;Message | Shows the message on the stage display output
 Stage&nbsp;Display&nbsp;Hide&nbsp;Message | Removes the stage display message
 Stage&nbsp;Display&nbsp;Layout | Sets the stage display layout. Index is a 0-based number (in the order shown in ProPresenter)
-Toggle&nbsp;Stage&nbsp;Display&nbsp;Layout | You can use this action to toggle (swap) between two selected stage display layouts with a single action (one button). Configure the action with the indexes of two stage display layouts and when this action is run the stage display layout will toggle back and forth between the two.  If neither of the configured layouts is active when this action is run, the first will will be selected. 
-
-**Tip: Intuitive Stage Display Toggle On A Single Button.**
-If you regularly use two stage display layouts, you can setup a single button with the "Toggle Stage Display Layout" action and set it's text title to $(propresenter:current_stage_display_name) so that it will always display the active stage display layout. Whenever you press this button, it will toggle between your two chosen layouts and let you know by changing the button title.
 
 ## Clocks (Timers)
 Command | Description

--- a/HELP.md
+++ b/HELP.md
@@ -6,9 +6,9 @@ Module for using ProPresenter with the Elgato Stream Deck and Companion
 ## Slides
 Command | Description
 ------- | -----------
-Next Slide | Advances to the next slide in the current document. If at the end of a document, will advance to the start of the next document in the playlist.
-Previous Slide | Moves to the previous slide in the current document. If at the start of a document, will move to the start of the previous document in the playlist.
-Specific Slide | Moves to that presentation/slide number. See the `Specific Slide` section below.
+Next&nbsp;Slide | Advances to the next slide in the current document. If at the end of a document, will advance to the start of the next document in the playlist.
+Previous&nbsp;Slide | Moves to the previous slide in the current document. If at the start of a document, will move to the start of the previous document in the playlist.
+Specific&nbsp;Slide | Moves to that presentation/slide number. See the `Specific Slide` section below.
 
 ### Specific Slide
 This action has two parameters:
@@ -41,12 +41,12 @@ The below image may make this more clear:
 ## Clear/Logo
 Command | Description
 ------- | -----------
-Clear All | Clears all the layers
-Clear Audio | Clears the audio track
-Clear Background | Clears only the background layer
-Clear Slide | Clears the current slide (foreground and background)
-Clear Telestrator | Clears all annotations drawn with the telestrator
-Clear to Logo | Clears all the layers and shows the logo image set in ProPresenter
+Clear&nbsp;All | Clears all the layers
+Clear&nbsp;Audio | Clears the audio track
+Clear&nbsp;Background | Clears only the background layer
+Clear&nbsp;Slide | Clears the current slide (foreground and background)
+Clear&nbsp;Telestrator | Clears all annotations drawn with the telestrator
+Clear&nbsp;to&nbsp;Logo | Clears all the layers and shows the logo image set in ProPresenter
 
 ### Clear All
 Note: When the `Clear All` action is triggered against ProPresenter for Windows, the current slide will be lost but on Mac it's preserved.
@@ -61,21 +61,21 @@ You can work around this PC limitation by using the `Specific Slide` action with
 ## Stage Display
 Command | Description
 ------- | -----------
-Stage Display Message | Shows the message on the stage display output
-Stage Display Hide Message | Removes the stage display message
-Stage Display Layout | Sets the stage display layout. Index is a 0-based number (in the order shown in ProPresenter)
-Toggle Stage Display Layout | You can use this action to toggle (swap) between two selected stage display layouts. Enter two indexes and when this action is run the stage display layout will toggle back and forth.  If neither of these layouts is active when this action is run, the first will will be selected. 
+Stage&nbsp;Display&nbsp;Message | Shows the message on the stage display output
+Stage&nbsp;Display&nbsp;Hide&nbsp;Message | Removes the stage display message
+Stage&nbsp;Display&nbsp;Layout | Sets the stage display layout. Index is a 0-based number (in the order shown in ProPresenter)
+Toggle&nbsp;Stage&nbsp;Display&nbsp;Layout | You can use this action to toggle (swap) between two selected stage display layouts with a single action (one button). Configure the action with the indexes of two stage display layouts and when this action is run the stage display layout will toggle back and forth between the two.  If neither of the configured layouts is active when this action is run, the first will will be selected. 
 
-**Tip: Intuitive stage display toggle.**
-If you regularly use two stage display layouts, you can setup a button with the "Toggle Stage Display Layout" and set it's text title to $(propresenter:current_stage_display_name) so it will always display the active stage display layout and when pressed it will toggle between your two chosen layouts.
+**Tip: Intuitive Stage Display Toggle On A Single Button.**
+If you regularly use two stage display layouts, you can setup a single button with the "Toggle Stage Display Layout" action and set it's text title to $(propresenter:current_stage_display_name) so that it will always display the active stage display layout. Whenever you press this button, it will toggle between your two chosen layouts and let you know by changing the button title.
 
 ## Clocks (Timers)
 Command | Description
 ------- | -----------
-Start Clock | Starts clock (timer) - identified by index (0 based)
-Stop Clock | Stops clock (timer) - identified by index (0 based)
-Reset Clock | Resets clock (timer) - identified by index (0 based)
-Update CountDown Clock | Update count-down timer with new duration - identified by index (0 based).  Note that if you send this command to a timer/clock that is not a count-down timer it will be converted to a count-down timer! "Duration" is the new duration value for the count-down timer in the format HH:MM:SS.  You may also use a shorthand format if you like. You can, if you want, leave out the HH and/or the MM values and they will default to zero - you can also leave out one or both of the ":" to enter just mins and/or seconds.  You can also change whether or not the countdown timer is able to over-run.
+Start&nbsp;Clock | Starts clock (timer) - identified by index (0 based)
+Stop&nbsp;Clock | Stops clock (timer) - identified by index (0 based)
+Reset&nbsp;Clock | Resets clock (timer) - identified by index (0 based)
+Update&nbsp;CountDown&nbsp;Clock | Update count-down timer with new duration - identified by index (0 based).  Note that if you send this command to a timer/clock that is not a count-down timer it will be converted to a count-down timer! "Duration" is the new duration value for the count-down timer in the format HH:MM:SS.  You may also use a shorthand format if you like. You can, if you want, leave out the HH and/or the MM values and they will default to zero - you can also leave out one or both of the ":" to enter just mins and/or seconds.  You can also change whether or not the countdown timer is able to over-run.
 
 **Tip: One-Touch Preset CountDown Timers.**
 If you use a lot of timers with commonly used values for duration, you might like to setup a few buttons that automatically reset and restart a count-down timer for your most commonly used durations. To make a single button do that for you, you can chain together the following three actions:
@@ -90,6 +90,6 @@ $(propresenter:current_slide) | The number of the active slide (>= 1), or "N/A" 
 $(propresenter:total_slides)  | The total number of slides in the current document, or "N/A" if unknown.
 $(propresenter:presentation_name) | The name of the current presentation, or "N/A" if unknown.
 $(propresenter:connection_status) | The current connection status to ProPresenter ("Disconnected" or "Connected").
-$(propresenter:watched_clock_current_time) | In the config of this module, you can specify the index of a clock (timer) that you want to monitor. This dynamic variable will be updated once per second to the current value of the clock specified. You could use this to display a live timer value on a button!
-$(propresenter:current_stage_display_index) | Index of the currently selected stage display layout (updated whenever a new layout is selected)
-$(propresenter:current_stage_display_name) | Name of the currently selected stage display layout (updated whenever a new layout is selected)
+$(propresenter:watched_clock_current_time) | In the config of this module, you can specify the index of a clock (timer) that you want to "watch". This dynamic variable will be updated once per second to the current value of the clock specified. You could use this to display a live timer value on a button!
+$(propresenter:current_stage_display_index) | Index of the currently selected stage display layout (This is updated whenever a new layout is selected.)
+$(propresenter:current_stage_display_name) | Name of the currently selected stage display layout (This is updated whenever a new layout is selected.)

--- a/index.js
+++ b/index.js
@@ -95,7 +95,7 @@ instance.prototype.init = function() {
 
 	self.initVariables();
 
-	if(self.config.host !== '' && self.config.port !== '') {
+	if (self.config.host !== '' && self.config.port !== '') {
 		self.connectToProPresenter();
 		self.startConnectionTimer();
 	}
@@ -206,7 +206,7 @@ instance.prototype.initVariables = function() {
 instance.prototype.updateVariable = function(name, value) {
 	var self = this;
 
-	if(self.currentState.dynamicVariables[name] === undefined) {
+	if (self.currentState.dynamicVariables[name] === undefined) {
 		self.log('warn', "Variable " + name + " does not exist");
 		return;
 	}
@@ -261,7 +261,7 @@ instance.prototype.setConnectionVariable = function(status, updateLog) {
 
 	self.updateVariable('connection_status', status);
 
-	if(updateLog) {
+	if (updateLog) {
 		self.log('info', "ProPresenter " + status);
 	}
 
@@ -294,7 +294,7 @@ instance.prototype.connectToProPresenter = function() {
 	// Disconnect if already connected
 	self.disconnectFromProPresenter();
 
-	if(self.config.host === '' || self.config.port === '') {
+	if (self.config.host === '' || self.config.port === '') {
 		return;
 	}
 
@@ -325,7 +325,7 @@ instance.prototype.connectToProPresenter = function() {
 		var wasConnected = self.currentState.internal.wsConnected;
 		self.emptyCurrentState();
 	
-		if(wasConnected === false) {
+		if (wasConnected === false) {
 			return;
 		}
 
@@ -515,7 +515,7 @@ instance.prototype.action = function(action) {
 		case 'slideNumber':
 			var index = self.currentState.internal.slideIndex;
 
-			if(opt.slide[0] === '-' || opt.slide[0] === '+') {
+			if (opt.slide[0] === '-' || opt.slide[0] === '+') {
 				// Move back/forward a relative number of slides.
 				index += parseInt(opt.slide.substring(1), 10) * ((opt.slide[0] === '+') ? 1 : -1);
 				index = Math.max(0, index);
@@ -524,7 +524,7 @@ instance.prototype.action = function(action) {
 				index = parseInt(opt.slide) - 1;
 			}
 
-			if(index < 0) {
+			if (index < 0) {
 				// Negative slide indexes are invalid. In such a case use the current slideIndex.
 				// This allows the "Specific Slide", when set to 0 (thus the index is -1), to
 				//  trigger the current slide again. Can be used to bring back a slide after using
@@ -533,7 +533,7 @@ instance.prototype.action = function(action) {
 			}
 
 			var presentationPath = self.currentState.internal.presentationPath;
-			if(opt.path !== undefined && opt.path.match(/^\d+$/) !== null) {
+			if (opt.path !== undefined && opt.path.match(/^\d+$/) !== null) {
 				// Is a relative presentation path. Refers to the current playlist, so extract it
 				//  from the current presentationPath and append the opt.path to it.
 				presentationPath = presentationPath.split(':')[0] + ':' + opt.path;
@@ -585,10 +585,12 @@ instance.prototype.action = function(action) {
 		case 'stageDisplayToggle':
 			var newStageDisplayIndex = opt.index1;
 			self.log('info', "toggle");
-			if (self.currentState.internal.slideIndex == opt.index1)
+			if (self.currentState.internal.slideIndex == opt.index1) {
 				newStageDisplayIndex = opt.index2;
-			else
+			}
+			else {
 				newStageDisplayIndex = opt.index1;
+			}
 			self.log('info',newStageDisplayIndex);
 			cmd = '{"action":"stageDisplaySetIndex","stageDisplayIndex":'+newStageDisplayIndex+'}';
 			break;
@@ -648,7 +650,7 @@ instance.prototype.onWebSocketMessage = function(message) {
 
 	switch(objData.action) {
 		case 'authenticate':
-			if(objData.authenticated === 1) {
+			if (objData.authenticated === 1) {
 				self.status(self.STATE_OK);
 				self.currentState.internal.wsConnected = true;
 				// Successfully authenticated. Request current state.
@@ -712,8 +714,9 @@ instance.prototype.onWebSocketMessage = function(message) {
 		
 		case 'clockCurrentTimes':
 			var objWatchedClock = objData.clockTimes;
-			if (self.config.indexOfClockToWatch >= 0 && self.config.indexOfClockToWatch < objData.clockTimes.length)
+			if (self.config.indexOfClockToWatch >= 0 && self.config.indexOfClockToWatch < objData.clockTimes.length) {
 				self.updateVariable('watched_clock_current_time', objData.clockTimes[self.config.indexOfClockToWatch]);
+			}
 			break;
 		
 		case 'stageDisplaySetIndex': // User (or someone,else) has set the StageDisplay (get stageDisplayIndex)
@@ -731,7 +734,7 @@ instance.prototype.onWebSocketMessage = function(message) {
 
 	}
 
-	if(objData.presentationPath !== undefined && objData.presentationPath !== self.currentState.internal.presentationPath) {
+	if (objData.presentationPath !== undefined && objData.presentationPath !== self.currentState.internal.presentationPath) {
 		// The presentationPath has changed. Update the path and request the information.
 		self.getProPresenterState();
 	}
@@ -745,7 +748,7 @@ instance.prototype.onWebSocketMessage = function(message) {
 instance.prototype.getProPresenterState = function() {
 	var self = this;
 
-	if(self.currentState.internal.wsConnected === false) {
+	if (self.currentState.internal.wsConnected === false) {
 		return;
 	}
 
@@ -754,7 +757,7 @@ instance.prototype.getProPresenterState = function() {
 		presentationSlideQuality: 0 // Setting to 0 stops Pro6 from including the slide preview image data (which is a lot of data) - no need to get slide preview images since we are not using them!
 	}));
 
-	if(self.currentState.dynamicVariables.current_slide === 'N/A') {
+	if (self.currentState.dynamicVariables.current_slide === 'N/A') {
 		// The currentSlide will be empty when the module first loads. Request it.
 		self.socket.send(JSON.stringify({
 			action: 'presentationSlideIndex'
@@ -769,7 +772,7 @@ instance.prototype.getProPresenterState = function() {
 instance.prototype.getStageDisplaysInfo = function() {
 	var self = this;
 
-	if(self.currentState.internal.wsConnected === false) {
+	if (self.currentState.internal.wsConnected === false) {
 		return;
 	}
 

--- a/index.js
+++ b/index.js
@@ -68,6 +68,7 @@ instance.prototype.config_fields = function () {
 			tooltip: 'Index of clock to watch.  Dynamic variable "watched_clock_current_time" will be updated with current value once every second.',
 			default: '0',
 			width: 2,
+			regex: self.REGEX_NUMBER
 		}
 	]
 };
@@ -386,7 +387,7 @@ instance.prototype.actions = function(system) {
 					label: 'Stage Display Index',
 					id: 'index',
 					default: 0,
-					regex: self.REGEX_SIGNED_NUMBER
+					regex: self.REGEX_NUMBER
 				}
 			]
 		},
@@ -399,7 +400,7 @@ instance.prototype.actions = function(system) {
 					id: 'index1',
 					default: 0,
 					tooltip: 'See the README for more information',
-					regex: self.REGEX_SIGNED_NUMBER
+					regex: self.REGEX_NUMBER
 				},
 				{
 					type: 'textinput',
@@ -407,7 +408,7 @@ instance.prototype.actions = function(system) {
 					id: 'index2',
 					default: 1,
 					tooltip: 'See the README for more information',
-					regex: self.REGEX_SIGNED_NUMBER
+					regex: self.REGEX_NUMBER
 				}
 			]
 		},
@@ -432,7 +433,7 @@ instance.prototype.actions = function(system) {
 					id: 'clockIndex',
 					default: 0,
 					tooltip: 'Zero based index of countdown clock - first one is 0, second one is 1 and so on...',
-					regex: self.REGEX_SIGNED_NUMBER
+					regex: self.REGEX_NUMBER
 				}
 			]
 		},
@@ -445,7 +446,7 @@ instance.prototype.actions = function(system) {
 					id: 'clockIndex',
 					default: 0,
 					tooltip: 'Zero based index of countdown clock - first one is 0, second one is 1 and so on...',
-					regex: self.REGEX_SIGNED_NUMBER
+					regex: self.REGEX_NUMBER
 				}
 			]
 		},
@@ -458,7 +459,7 @@ instance.prototype.actions = function(system) {
 					id: 'clockIndex',
 					default: 0,
 					tooltip: 'Zero based index of countdown clock - first one is 0, second one is 1 and so on...',
-					regex: self.REGEX_SIGNED_NUMBER
+					regex: self.REGEX_NUMBER
 				}
 			]
 		},
@@ -471,7 +472,7 @@ instance.prototype.actions = function(system) {
 					id: 'clockIndex',
 					default: 0,
 					tooltip: 'Zero based index of countdown clock - first one is 0, second one is 1 and so on...',
-					regex: self.REGEX_SIGNED_NUMBER
+					regex: self.REGEX_NUMBER
 				},
 				{
 					type: 'textinput',
@@ -586,8 +587,7 @@ instance.prototype.action = function(action) {
 			var newStageDisplayIndex = opt.index1;
 			if (self.currentState.internal.slideIndex == opt.index1) {
 				newStageDisplayIndex = opt.index2;
-			}
-			else {
+			} else {
 				newStageDisplayIndex = opt.index1;
 			}
 			cmd = '{"action":"stageDisplaySetIndex","stageDisplayIndex":'+newStageDisplayIndex+'}';

--- a/index.js
+++ b/index.js
@@ -93,7 +93,8 @@ instance.prototype.init = function() {
 	var self = this;
 	debug = self.debug;
 	log = self.log;
-
+	self.init_presets(); 
+	
 	self.initVariables();
 
 	if (self.config.host !== '' && self.config.port !== '') {
@@ -116,6 +117,156 @@ instance.prototype.destroy = function() {
 	debug("destroy", self.id);
 };
 
+
+/**
+* Define button presets
+*/
+instance.prototype.init_presets = function () {
+	var self = this;
+
+	var presets = [
+		{
+			category: 'Stage Display',
+			label: 'This button displays the name of current stage display layout. Pressing it will toggle back and forth between the two selected stage display layouts in the down and up actions.',
+			bank: {
+				style: 'text',
+				text: '$(propresenter:current_stage_display_name)',
+				size: '18',
+				color: self.rgb(255,255,255),
+				bgcolor: self.rgb(153,0,255),
+				latch: true
+			},
+			actions: [
+				{
+					action: 'stageDisplayLayout',
+					options: {
+						index: 0,
+					}
+				}
+			],
+			release_actions: [
+				{
+					action: 'stageDisplayLayout',
+					options: {
+						index: 1,
+					}
+				}
+			]
+		},
+		{
+			category: 'Stage Display',
+			label: 'This button will activate the selected (by index) stage display layout.',
+			bank: {
+				style: 'text',
+				text: 'Select Layout',
+				size: '18',
+				color: self.rgb(255,255,255),
+				bgcolor: self.rgb(153,0,255)
+			},
+			actions: [
+				{
+					action: 'stageDisplayLayout',
+					options: {
+						index: 0,
+					}
+				}
+			]
+		},
+		{
+			category: 'Count Down Clocks',
+			label: 'This button will reset a selected (by index) count-down clock to 5 mins and automatically start it.  If you send this to a non-count-down clock it will be converted to one!',
+			bank: {
+				style: 'text',
+				text: 'Clock '+self.config.indexOfClockToWatch+'\\n5 mins',
+				size: '18',
+				color: self.rgb(255,255,255),
+				bgcolor: self.rgb(0,153,51)
+			},
+			actions: [
+				{
+					action: 'clockUpdate',
+					options: {
+						clockIndex: self.config.indexOfClockToWatch, // N.B. If user updates indexOfClockToWatch, this preset default will not be updated until module is reloaded.
+						clockTime: '00:05:00',
+						clockOverRun: false,
+					}
+				},
+				{
+					action: 'clockReset',
+					delay: 100,
+					options: {
+						clockIndex: self.config.indexOfClockToWatch, // N.B. If user updates indexOfClockToWatch, this preset default will not be updated until module is reloaded.
+					}
+				},
+				{
+					action: 'clockStart',
+					delay: 200,
+					options: {
+						clockIndex: self.config.indexOfClockToWatch, // N.B. If user updates indexOfClockToWatch, this preset default will not be updated until module is reloaded.
+					}
+				}
+			]
+		},
+		{
+			category: 'Count Down Clocks',
+			label: 'This button will START a clock selected by index (0-based). If you change the index, and still want to display the current time on the button, make sure to also update the index of the clock to watch in this modules config to match.',
+			bank: {
+				style: 'text',
+				text: 'Start\\nClock '+self.config.indexOfClockToWatch+'\\n$(propresenter:watched_clock_current_time)',
+				size: '14',
+				color: self.rgb(255,255,255),
+				bgcolor: self.rgb(0,153,51)
+			},
+			actions: [
+				{
+					action: 'clockStart',
+					options: {
+						clockIndex: self.config.indexOfClockToWatch, // N.B. If user updates indexOfClockToWatch, this preset default will not be updated until module is reloaded.
+					}
+				}
+			]
+		},
+		{
+			category: 'Count Down Clocks',
+			label: 'This button will STOP a clock selected by index (0-based). If you change the index, and still want to display the current time on the button, make sure to also update the index of the clock to watch in this modules config to match.',
+			bank: {
+				style: 'text',
+				text: 'Stop\\nClock '+self.config.indexOfClockToWatch+'\\n$(propresenter:watched_clock_current_time)',
+				size: '14',
+				color: self.rgb(255,255,255),
+				bgcolor: self.rgb(204,0,0)
+			},
+			actions: [
+				{
+					action: 'clockStop',
+					options: {
+						clockIndex: self.config.indexOfClockToWatch, // N.B. If user updates indexOfClockToWatch, this preset default will not be updated until module is reloaded.
+					}
+				}
+			]
+		},
+		{
+			category: 'Count Down Clocks',
+			label: 'This button will RESET a clock selected by index (0-based). If you change the index, and still want to display the current time on the button, make sure to also update the index of the clock to watch in this modules config to match.',
+			bank: {
+				style: 'text',
+				text: 'Reset\\nClock '+self.config.indexOfClockToWatch+'\\n$(propresenter:watched_clock_current_time)',
+				size: '14',
+				color: self.rgb(255,255,255),
+				bgcolor: self.rgb(255,102,0)
+			},
+			actions: [
+				{
+					action: 'clockReset',
+					options: {
+						clockIndex: self.config.indexOfClockToWatch, // N.B. If user updates indexOfClockToWatch, this preset default will not be updated until module is reloaded.
+					}
+				}
+			]
+		},
+	];
+	self.setPresetDefinitions(presets);
+}
 
 /**
  * Initialize an empty current state.
@@ -469,7 +620,6 @@ instance.prototype.actions = function(system) {
 			 	},
 			]
 		},
-
 	});
 };
 

--- a/index.js
+++ b/index.js
@@ -584,14 +584,12 @@ instance.prototype.action = function(action) {
 		
 		case 'stageDisplayToggle':
 			var newStageDisplayIndex = opt.index1;
-			self.log('info', "toggle");
 			if (self.currentState.internal.slideIndex == opt.index1) {
 				newStageDisplayIndex = opt.index2;
 			}
 			else {
 				newStageDisplayIndex = opt.index1;
 			}
-			self.log('info',newStageDisplayIndex);
 			cmd = '{"action":"stageDisplaySetIndex","stageDisplayIndex":'+newStageDisplayIndex+'}';
 			break;
 


### PR DESCRIPTION
Added new dynamic variables:
* current_stage_display_name: (The name of active stage display layout - updated when changed)
* current_stage_display_index: (The index of active stage display layout - updated when changed)
* watched_clock_current_time: (The current value of a clock/timer that is selected in the module config. In the Pro6 module config, you can now specify the index of a clock you wish to keep track of and this dynamic variable will be updated once per second)

Added new action "Toggle Stage Display Layout" - You can specify two Stage Display Layouts (by index) and the action will toggle back and forth between them. (It's nice to put the current_stage_display_name on this button title).

Made getProPresenterState more efficient by updating the 'presentationCurrent' action to include presentationSlideQuality: 0 attribute. Setting presentationSlideQuality to 0 stops Pro6 from including the slide preview image data (which is a lot of data) - no need to get slide preview images since we are not using them!