### PR TITLE
Added Timeline commands

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -97,6 +97,14 @@ If you use a lot of timers with commonly used values for duration, you might lik
 
 Use *relative delays*, to ensure these three action arrive in the correct order (or if you prefer absolute delays, make sure the second action has less delay than the third)
 
+## Timeline
+Command | Description
+------- | -----------
+Timeline&nbsp;Play/Pause | Toggle play/paused state of timeline for a specific presentation (See PresenationPath explanation above)
+Timeline&nbsp;Rewind  | Rewind timeline for a specific presentation (See PresenationPath explanation above)
+
+Please Note: There is NO direct feedback from ProPresenter for when a timeline is playing or paused - so this cannot be shown to users on the StreamDeck!
+
 # Dynamic Variables
 Variable | Description
 -------- | -----------

--- a/index.js
+++ b/index.js
@@ -884,12 +884,38 @@ instance.prototype.actions = function(system) {
 					label: 'Audio Item Playlist Path',
 					id: 'audioChildPath',
 					default: '',
-					tooltip: 'Playlist path format 0.0',
+					tooltip: 'PresentationPath format - See the README for more information',
 					regex: '/^$|^\\d+$|^\\d+(\\.\\d+)*:\\d+$/'
 				}
 			]
 		},
-		'audioPlayPause': { label: 'Audio Play/Pause' }
+		'audioPlayPause': { label: 'Audio Play/Pause' },
+		'timelinePlayPause': {
+			label: 'Timeline Play/Pause',
+			options: [
+				{
+					type: 'textinput',
+					label: 'Presentation Path',
+					id: 'presentationPath',
+					default: '',
+					tooltip: 'PresentationPath format - See the README for more information',
+					regex: '/^$|^\\d+$|^\\d+(\\.\\d+)*:\\d+$/'
+				}
+			]
+		},
+		'timelineRewind': {
+			label: 'Timeline Rewind',
+			options: [
+				{
+					type: 'textinput',
+					label: 'Presentation Path',
+					id: 'presentationPath',
+					default: '',
+					tooltip: 'PresentationPath format - See the README for more information',
+					regex: '/^$|^\\d+$|^\\d+(\\.\\d+)*:\\d+$/'
+				}
+			]
+		}
 	});
 };
 
@@ -1099,6 +1125,18 @@ instance.prototype.action = function(action) {
 		case 'audioPlayPause':
 			cmd = {
 				action: "audioPlayPause"
+			};
+			break;
+		case 'timelinePlayPause':
+			cmd = {
+				action: "timelinePlayPause",
+				presentationPath: opt.presentationPath
+			};
+			break;
+		case 'timelineRewind':
+			cmd = {
+				action: "timelineRewind",
+				presentationPath: opt.presentationPath
 			};
 			break;
 	};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 		"propresenter6",
 		"propresenter"
 	],
-	"version": "2.2.0",
+	"version": "2.3.0",
 	"api_version": "1.0.0",
 	"keywords": [
 		"Software",


### PR DESCRIPTION
Added two new commands for control of Timeline.
1. Timeline Play/Pause
2. Timeline Rewind

Tested on ProPresenter versions: 6.4 (MacOS) and 6.1.6.2 (Windows)