### PR TITLE
Allow connection to loopback, improve config validation/layout and misc spelling fixes.

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -31,7 +31,7 @@ Now you have all the info you need to go to the ProPresenter Companion module co
 
 If you chose to also enable the stage display app option in ProPresenter preferences (so your StreamDeck can display "Video Countdown" timers) then you can also select "Yes" for the configuration field "Connect to StageDisplay (Only required for video countdown timer)" and enter the stage display password.
 
-N.B. At the time of writing this module, there is a bug in ProPresenter 6 where if you choose to enter a Port number for the stage display app - it will actually ingore it and use the "main" network port you recorded in step 8 above.
+N.B. At the time of writing this module, there is a bug in ProPresenter 6 where if you choose to enter a Port number for the stage display app - it will actually ignore it and use the "main" network port you recorded in step 8 above.
 
 
 # Commands
@@ -98,7 +98,7 @@ You can work around this PC limitation by using the `Specific Slide` action with
 ## Messages (On Output screen)
 Command | Description
 ------- | -----------
-Show&nbsp;Message | Shows the message on the stage display output. You can pass values for message tokens, but you must do so very carefully - a typo here can crash ProPresenter.  Crashes can cause data loss, and ruin your setup. Learn how to correctly enter message tokens by reading below. Always type carefully and double-check. Get it right on a test machine first! The correct way to pass values for message tokens is as two lists. The two lists work together to form token NAME and token VALUE pairs.  The first list is a comma-separated list of token NAMES and the second is a comma-separated list of token VALUES. The number of items in eash list should match - e.g. if you supply two token NAMES, then you should supply two token VALUES to make matching pairs. All token names in your list *MUST* match the token names defined in the message within ProPresenter (or else Pro6 will likely crash).  The token values can be any text. You don't have to pass *all* the token names/values pairs - any name/values that you don't include will be treated as and displayed as blank. You don't have to pass any token names/values if you don't need to. Static messages without any tokens are safe - you can't make a typo if you leave the token names and token values list blank! If one of your token names or token values needs to have a comma in it, you can type a double comma (,,) to insert a literal comma - this works in either a token name or a token value. Again, make certain that your list of token NAMES perfectly match the names of the tokens defined in the message within Pro6 - Pro6 won't crash if they match perfectly - so be carefull!
+Show&nbsp;Message | Shows the message on the stage display output. You can pass values for message tokens, but you must do so very carefully - a typo here can crash ProPresenter.  Crashes can cause data loss, and ruin your setup. Learn how to correctly enter message tokens by reading below. Always type carefully and double-check. Get it right on a test machine first! The correct way to pass values for message tokens is as two lists. The two lists work together to form token NAME and token VALUE pairs.  The first list is a comma-separated list of token NAMES and the second is a comma-separated list of token VALUES. The number of items in each list should match - e.g. if you supply two token NAMES, then you should supply two token VALUES to make matching pairs. All token names in your list *MUST* match the token names defined in the message within ProPresenter (or else Pro6 will likely crash).  The token values can be any text. You don't have to pass *all* the token names/values pairs - any name/values that you don't include will be treated as and displayed as blank. You don't have to pass any token names/values if you don't need to. Static messages without any tokens are safe - you can't make a typo if you leave the token names and token values list blank! If one of your token names or token values needs to have a comma in it, you can type a double comma (,,) to insert a literal comma - this works in either a token name or a token value. Again, make certain that your list of token NAMES perfectly match the names of the tokens defined in the message within Pro6 - Pro6 won't crash if they match perfectly - so be careful!
 Hide&nbsp;Message | Removes a message from output screen.
 
 Messages are identified by Index. Index is a 0-based, where the first message is 0, and then count up through the messages in the order shown in the list of ProPresenter messages.
@@ -110,7 +110,7 @@ Stage&nbsp;Display&nbsp;Message | Shows the message on the stage display output
 Stage&nbsp;Display&nbsp;Hide&nbsp;Message | Removes the stage display message
 Stage&nbsp;Display&nbsp;Layout | Sets the stage display layout.
 
-Stage Displays are indentified by index. Index is a 0-based number, where the first layout is 0 and then count up through the stage display layouts in the order shown in ProPresenters list of stage display layouts.
+Stage Displays are identified by index. Index is a 0-based number, where the first layout is 0 and then count up through the stage display layouts in the order shown in ProPresenters list of stage display layouts.
 
 
 ## Clocks (Timers)
@@ -119,7 +119,7 @@ Command | Description
 Start&nbsp;Clock | Starts clock (timer) - identified by index (0 based)
 Stop&nbsp;Clock | Stops clock (timer) - identified by index (0 based)
 Reset&nbsp;Clock | Resets clock (timer) - identified by index (0 based)
-Update&nbsp;Clock | Update clock/timer with a new duration - identified by index (0 based). You must specify the type of clock as either Count Down Timer, Count Down To Time or Elapsed Time. (Note that any clock you update will be changed to the the selected type.)  "Duration" is the new duration value for the count-down timer in the format HH:MM:SS. (It is also the starting time for Elapsed Time clocks. You may also use a shorthand format if you like. You can, if you want, leave out the HH and/or the MM values and they will default to zero - you can also leave out one or both of the ":" to enter just mins and/or seconds.  You can control overrun for all clock types.  AM/PM is only needed for Count Down To Time clocks.
+Update&nbsp;Clock | Update clock/timer with a new duration - identified by index (0 based). You must specify the type of clock as either Countdown Timer, Countdown To Time or Elapsed Time. (Note that any clock you update will be changed to the the selected type.)  "Duration" is the new duration value for the count-down timer in the format HH:MM:SS. (It is also the starting time for Elapsed Time clocks. You may also use a shorthand format if you like. You can, if you want, leave out the HH and/or the MM values and they will default to zero - you can also leave out one or both of the ":" to enter just mins and/or seconds.  You can control overrun for all clock types.  AM/PM is only needed for Countdown To Time clocks.
 
 **Tip: One-Touch Preset CountDown Timers.**
 If you use a lot of timers with commonly used values for duration, you might like to setup a few buttons that automatically reset and restart a count-down timer for your most commonly used durations. To make a single button do that for you, you can chain together the following three actions:
@@ -132,8 +132,8 @@ Use *relative delays*, to ensure these three action arrive in the correct order 
 ## Timeline
 Command | Description
 ------- | -----------
-Timeline&nbsp;Play/Pause | Toggle play/paused state of timeline for a specific presentation (See PresenationPath explanation above)
-Timeline&nbsp;Rewind  | Rewind timeline for a specific presentation (See PresenationPath explanation above)
+Timeline&nbsp;Play/Pause | Toggle play/paused state of timeline for a specific presentation (See PresentationPath explanation above)
+Timeline&nbsp;Rewind  | Rewind timeline for a specific presentation (See PresentationPath explanation above)
 
 Please Note: There is NO direct feedback from ProPresenter for when a timeline is playing or paused - so this cannot be shown to users on the StreamDeck!
 

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ function instance(system, id, config) {
 
 
 /**
- * The current state of ProPresentation.
+ * The current state of ProPresenter.
  * Initially populated by emptyCurrentState().
  *
  * .internal contains the internal state of the module
@@ -72,7 +72,7 @@ instance.prototype.config_fields = function () {
 			width: 4,
 			regex: self.REGEX_NUMBER
 		},
-		 {
+		{
 			type: 'text',
 			id: 'info',
 			width: 12,
@@ -86,7 +86,7 @@ instance.prototype.config_fields = function () {
 			default: 'no',
 			width: 6,
 			choices: [ { id: 'no', label: 'No' }, { id: 'yes', label: 'Yes' } ]
-		 },
+		},
 		{
 			type: 'textinput',
 			id: 'sdport',
@@ -522,7 +522,7 @@ instance.prototype.setSDConnectionVariable = function(status, updateLog) {
 	self.updateVariable('sd_connection_status', status);
 
 	if (updateLog) {
-		self.log('info', "ProPresenter StageDisplay " + status);
+		self.log('info', "ProPresenter Stage Display " + status);
 	}
 
 };
@@ -638,7 +638,7 @@ instance.prototype.connectToProPresenterSD = function() {
 		self.config.sdport = self.config.port;
 	}
 
-	// Connect to StageDisplay websocket of ProPresenter
+	// Connect to Stage Display websocket of ProPresenter
 	self.sdsocket = new WebSocket('ws://'+self.config.host+':'+self.config.sdport+'/stagedisplay');
 
 	self.sdsocket.on('open', function open() {
@@ -651,13 +651,13 @@ instance.prototype.connectToProPresenterSD = function() {
 
 	});
 
-	// Since StageDisplay connection is not required to function - we will only send a warning if it fails
+	// Since Stage Display connection is not required to function - we will only send a warning if it fails
 	self.sdsocket.on('error', function (err) {
 		// If stage display can't connect - it's not really a "code red" error - since *most* of the core functionally does not require it.
 		// Therefore, a failure to connect stage display is more of a warning state.
 		// However, if the module is already in error, then we should not lower that to warning!
 		if (self.currentStatus !== self.STATUS_ERROR && self.config.use_sd === 'yes') {
-			self.status(self.STATUS_WARNING, 'OK, But Stage Display not connected');
+			self.status(self.STATUS_WARNING, 'OK - Stage Display not connected');
 		}
 	});
 

--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ instance.prototype.config_fields = function () {
 			id: 'host',
 			label: 'ProPresenter IP',
 			width: 6,
-			default: '127.0.0.1',
+			default: '',
 			regex: self.REGEX_IP
 		},
 		{
@@ -54,7 +54,8 @@ instance.prototype.config_fields = function () {
 			id: 'port',
 			label: 'ProPresenter Port',
 			width: 6,
-			default: ''
+			default: '',
+			regex: self.REGEX_PORT
 		},
 		{
 			type: 'textinput',
@@ -85,7 +86,9 @@ instance.prototype.config_fields = function () {
 			label: 'Optional Custom StageDisplay App Port',
 			tooltip: 'Optionally set in ProPresenter Preferences. ProPresenter Port (above) will be used if left blank.',
 			width: 6,
-			default: ''
+			default: '',
+			// regex from instance_skel.js, but modified to make the port optional
+			regex: '/^([1-9]|[1-8][0-9]|9[0-9]|[1-8][0-9]{2}|9[0-8][0-9]|99[0-9]|[1-8][0-9]{3}|9[0-8][0-9]{2}|99[0-8][0-9]|999[0-9]|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-4])$|^$/'
 		},
 		{
 			type: 'textinput',
@@ -560,12 +563,11 @@ instance.prototype.connectToProPresenter = function() {
 	// Disconnect if already connected
 	self.disconnectFromProPresenter();
 
-	if (self.config.host === undefined || self.config.port === '') {
+	// ~~ is a double NOT bitwise operator. Will change .port to a numeric value, including null, undefined, "" to 0.
+	if (self.config.host === undefined || ~~self.config.port === 0) {
 		return;
 	}
-	if (self.config.host === '127.0.0.1') {
-		return;
-	}
+
 	// Connect to remote control websocket of ProPresenter
 	self.socket = new WebSocket('ws://'+self.config.host+':'+self.config.port+'/remote');
 

--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ instance.prototype.config_fields = function () {
 			id: 'info',
 			width: 12,
 			label: 'Stage Display Settings (Optional)',
-			value: "The following fields are only needed if you want the video countdown information in a dynamic variable."
+			value: "The following fields are only needed if you want the video countdown timer in a dynamic variable."
 		},
 		{
 			type: 'dropdown',
@@ -219,8 +219,8 @@ instance.prototype.init_presets = function () {
 			]
 		},
 		{
-			category: 'Count Down Clocks',
-			label: 'This button will reset a selected (by index) clock to a 5 min count-down clock and automatically start it.',
+			category: 'Countdown Clocks',
+			label: 'This button will reset a selected (by index) clock to a 5 min countdown clock and automatically start it.',
 			bank: {
 				style: 'text',
 				text: 'Clock '+self.config.indexOfClockToWatch+'\\n5 mins',
@@ -255,7 +255,7 @@ instance.prototype.init_presets = function () {
 			]
 		},
 		{
-			category: 'Count Down Clocks',
+			category: 'Countdown Clocks',
 			label: 'This button will START a clock selected by index (0-based). If you change the index, and still want to display the current time on the button, make sure to also update the index of the clock to watch in this modules config to match.',
 			bank: {
 				style: 'text',
@@ -274,7 +274,7 @@ instance.prototype.init_presets = function () {
 			]
 		},
 		{
-			category: 'Count Down Clocks',
+			category: 'Countdown Clocks',
 			label: 'This button will STOP a clock selected by index (0-based). If you change the index, and still want to display the current time on the button, make sure to also update the index of the clock to watch in this modules config to match.',
 			bank: {
 				style: 'text',
@@ -293,7 +293,7 @@ instance.prototype.init_presets = function () {
 			]
 		},
 		{
-			category: 'Count Down Clocks',
+			category: 'Countdown Clocks',
 			label: 'This button will RESET a clock selected by index (0-based). If you change the index, and still want to display the current time on the button, make sure to also update the index of the clock to watch in this modules config to match.',
 			bank: {
 				style: 'text',
@@ -394,7 +394,7 @@ instance.prototype.initVariables = function() {
 			name:  'current_stage_display_name'
 		},
 		{
-			label: 'Video CountDown Timer',
+			label: 'Video Countdown Timer',
 			name:  'video_countdown_timer'
 		}
 	];
@@ -829,14 +829,14 @@ instance.prototype.actions = function(system) {
 					id: 'clockType',
 					default: '0',
 					tooltip: 'If the clock specified by the Clock Number is not of this type it will be UPDATED/CONVERTED this type.',
-					choices: [ { id: '0', label: 'Count Down Timer' }, { id: '1', label: 'Count Down To Time' }, { id: '2', label: 'Elapsed Time'} ]
+					choices: [ { id: '0', label: 'Countdown Timer' }, { id: '1', label: 'Countdown To Time' }, { id: '2', label: 'Elapsed Time'} ]
 				},
 				{
 					type: 'dropdown',
 					label: 'Clock Is PM',
 					id: 'clockIsPM',
 					default: '0',
-					tooltip: 'Only Required for Count Down To Time Clock - otherwise this is ignored.',
+					tooltip: 'Only Required for Countdown To Time Clock - otherwise this is ignored.',
 					choices: [ { id: '0', label: 'No' }, { id: '1', label: 'Yes' } ]
 				},
 				{

--- a/index.js
+++ b/index.js
@@ -66,24 +66,31 @@ instance.prototype.config_fields = function () {
 		{
 			type: 'textinput',
 			id: 'indexOfClockToWatch',
-			label: 'Index of Clock To Watch',
+			label: 'Index of Clock to Watch',
 			tooltip: 'Index of clock to watch.  Dynamic variable "watched_clock_current_time" will be updated with current value once every second.',
 			default: '0',
-			width: 2,
+			width: 4,
 			regex: self.REGEX_NUMBER
 		},
 		 {
+			type: 'text',
+			id: 'info',
+			width: 12,
+			label: 'Stage Display Settings (Optional)',
+			value: "The following fields are only needed if you want the video countdown information in a dynamic variable."
+		},
+		{
 			type: 'dropdown',
-			label: 'Connect to StageDisplay (Only required for video countdown timer)',
+			label: 'Connect to Stage Display',
 			id: 'use_sd',
 			default: 'no',
-			width: 8,
+			width: 6,
 			choices: [ { id: 'no', label: 'No' }, { id: 'yes', label: 'Yes' } ]
 		 },
 		{
 			type: 'textinput',
 			id: 'sdport',
-			label: 'Optional Custom StageDisplay App Port',
+			label: 'Stage Display App Port',
 			tooltip: 'Optionally set in ProPresenter Preferences. ProPresenter Port (above) will be used if left blank.',
 			width: 6,
 			default: '',
@@ -93,7 +100,7 @@ instance.prototype.config_fields = function () {
 		{
 			type: 'textinput',
 			id: 'sdpass',
-			label: 'StageDisplay App Password',
+			label: 'Stage Display App Password',
 			width: 8,
 		}
 	]

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 		"propresenter6",
 		"propresenter"
 	],
-	"version": "2.3.1",
+	"version": "2.3.2",
 	"api_version": "1.0.0",
 	"keywords": [
 		"Software",


### PR DESCRIPTION
A bunch of small changes:
- Connections to `127.0.0.1` are allowed again.
  - Removed "127.0.0.1" as the default value to ensure people fill in the right value and don't rely on a potentially incorrect default.
- Changed the config layout slightly to better lay out the fields.
- Added some missing validations on the two Ports config fields.
- Misc spelling and consistency in labels/comments/HELP.md
- Version bump.

Closes #21, closes #22, and closes #24