### PR TITLE
Added Pro7 compatibility

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -24,7 +24,7 @@ You can control ProPresenter on any computer within the same network, you just n
 
 If you want to connect to ProPresenter on the *same* computer that you are running Companion on, you can use the special looback IP address of 127.0.0.1 (which is the default setting)
 
-If your ProPresenter (and Companion) computers have a choice of using either wireless or a wired connection, always use wired, as a wired network connection is *typically* more reliable and has better latency (good for remote control).
+If the computers running ProPresenter and Companion have a choice of using either a wireless or a wired network connection, then it is recommended to always use wired. This is because a wired network connection is *typically* more reliable and has better latency (which is better for remote control).
 
 ## Configure the ProPresenter module in Companion
 Now you have all the info you need to go to the ProPresenter Companion module configuration and enter the IP address of the computer running ProPresenter as well as the ProPresenter port number and controller password that you took note of from ProPresenter network preferences.

--- a/HELP.md
+++ b/HELP.md
@@ -12,18 +12,22 @@ Module for using ProPresenter 6 with the Elgato Stream Deck and Companion. Requi
 6. Check the "Controller" option (if it is not already enabled).
 7. Enter a controller password (or take note of the existing controller password).
 8. Take a note of the Port number (to the right of the Network Name) - this is typically 4-5 digits.
-9. If you would like your StreamDeck to be able to display "Video CountDown" timers, then you will also need to check the option for "Enable Stage Display App" and enter (or take note of the existing) password.
+9. If you would like your StreamDeck to be able to display "Video CountDown" timers, then you will also need to check the option for "Enable Stage Display App" and enter a new password (or take note of the existing password).
 9. Close ProPresenter preferences window.
 
 ## Get the IP address of the computer running ProPresenter
-Use your knowledge of networking (or Google) to get the IP address of the computer running ProPresenter.
-Tip: You can control ProPresenter on any computer within the same network, you just need to know the IP address. If you want to connect to ProPresenter on the *same* computer that you are running Companion on, you can use the special looback IP address of 127.0.0.1
-If your ProPresenter (and Companion) computers have a choice of using either wireless or a wired connection, go for wired as a wired network connection is *typically* more reliable and has better latency - which is what you want when doing remote control!
+You can control ProPresenter on any computer within the same network, you just need to know the ProPresenter computer IP address. Use your knowledge of networking (or Google how) to get the IP address of the *computer running ProPresenter*.
+
+### Networking Tips:
+
+If you want to connect to ProPresenter on the *same* computer that you are running Companion on, you can use the special looback IP address of 127.0.0.1
+
+If your ProPresenter (and Companion) computers have a choice of using either wireless or a wired connection, always use wired, as a wired network connection is *typically* more reliable and has better latency (good for remote control).
 
 ## Configure the ProPresenter module in Companion
 Goto the module config and enter the IP address of the computer running ProPresenter.
 Enter the port number and password that you took note of from ProPresenter network preferences.
-If you chose to also enable the stage display app option in ProPresenter preferences (so your StreamDeck can display "Video Countdown" timers, then you can also select "Yes" for the configuration field "Connect to StageDisplay (Only required for video countdown timer)" and enter the stage display password.
+If you chose to also enable the stage display app option in ProPresenter preferences (so your StreamDeck can display "Video Countdown" timers) then you can also select "Yes" for the configuration field "Connect to StageDisplay (Only required for video countdown timer)" and enter the stage display password.
 N.B. At the time of writing this module, there is a bug in ProPresenter 6 where if you choose to enter a Port number for the stage display app - it will actually ingore it and use the "main" network port you recorded in step 8 above.
 
 

--- a/HELP.md
+++ b/HELP.md
@@ -22,7 +22,7 @@ You can control ProPresenter on any computer within the same network, you just n
 
 ### Networking Tips:
 
-If you want to connect to ProPresenter on the *same* computer that you are running Companion on, you can use the special looback IP address of 127.0.0.1
+If you want to connect to ProPresenter on the *same* computer that you are running Companion on, you can use the special looback IP address of 127.0.0.1 (which is the default setting)
 
 If your ProPresenter (and Companion) computers have a choice of using either wireless or a wired connection, always use wired, as a wired network connection is *typically* more reliable and has better latency (good for remote control).
 

--- a/HELP.md
+++ b/HELP.md
@@ -1,11 +1,11 @@
-# Companion-module: ProPresenter6
+# Companion-module: ProPresenter6/7
 
 Module for using ProPresenter 6 with the Elgato Stream Deck and Companion. Requires a network connection to ProPresenter via it's Remote network port.
 
 *Optionally, you can also configure a connection to the Stage Display App port if you want to track the Video CountDown Timer for any video that is playing.*
 
 # Setup Guide.
-## Enable networking in ProPresenter if you haven't already done so... 
+## Enable networking in ProPresenter if you haven't already done so...
 1. Open ProPresenter and then open the "ProPresenter 6" Menu.
 2. Select "Preferences..." to open the ProPresenter Preferences window.
 3. Select the Network tab to configure ProPresenter network preferences.
@@ -31,7 +31,7 @@ Now you have all the info you need to go to the ProPresenter Companion module co
 
 If you chose to also enable the stage display app option in ProPresenter preferences (so your StreamDeck can display "Video Countdown" timers) then you can also select "Yes" for the configuration field "Connect to StageDisplay (Only required for video countdown timer)" and enter the stage display password.
 
-N.B. At the time of writing this module, there is a bug in ProPresenter 6 where if you choose to enter a Port number for the stage display app - it will actually ingore it and use the "main" network port you recorded in step 8 above.
+N.B. At the time of writing this module, there is a bug in ProPresenter 6 where if you choose to enter a Port number for the stage display app - it will actually ignore it and use the "main" network port you recorded in step 8 above.
 
 
 # Commands
@@ -51,14 +51,14 @@ A whole number greater than 0 will move the presentation to that slide number.
 
 A slide number of `0` will trigger the current slide, which can be used to bring back a slide that was cleared using `Clear All` or `Clear Slide`.
 
-A relative number (prefixed with `+` or `-`) will move the presentation +/- that many slides. `+3` will jump ahead three slides, and `-2` will jump back two slides. Try to avoid using `-1` or `+1` relative numbers; use the `Next Slide` and `Previous Slide` actions instead, as they perform better. 
+A relative number (prefixed with `+` or `-`) will move the presentation +/- that many slides. `+3` will jump ahead three slides, and `-2` will jump back two slides. Try to avoid using `-1` or `+1` relative numbers; use the `Next Slide` and `Previous Slide` actions instead, as they perform better.
 
 
 **Presentation Path**: Lets you trigger a slide in a different presentation, even from a different playlist.
 
 *Important: Presentation path numbering starts at 0, meaning `0` will trigger a slide in the first presentation in the playlist.*
 
-A single number, like `3`, will let you trigger a slide in the *fourth* presentation in the **current playlist**. 
+A single number, like `3`, will let you trigger a slide in the *fourth* presentation in the **current playlist**.
 
 A path like `1:3` will trigger presentation #4 in playlist #2.
 
@@ -98,7 +98,7 @@ You can work around this PC limitation by using the `Specific Slide` action with
 ## Messages (On Output screen)
 Command | Description
 ------- | -----------
-Show&nbsp;Message | Shows the message on the stage display output. You can pass values for message tokens, but you must do so very carefully - a typo here can crash ProPresenter.  Crashes can cause data loss, and ruin your setup. Learn how to correctly enter message tokens by reading below. Always type carefully and double-check. Get it right on a test machine first! The correct way to pass values for message tokens is as two lists. The two lists work together to form token NAME and token VALUE pairs.  The first list is a comma-separated list of token NAMES and the second is a comma-separated list of token VALUES. The number of items in eash list should match - e.g. if you supply two token NAMES, then you should supply two token VALUES to make matching pairs. All token names in your list *MUST* match the token names defined in the message within ProPresenter (or else Pro6 will likely crash).  The token values can be any text. You don't have to pass *all* the token names/values pairs - any name/values that you don't include will be treated as and displayed as blank. You don't have to pass any token names/values if you don't need to. Static messages without any tokens are safe - you can't make a typo if you leave the token names and token values list blank! If one of your token names or token values needs to have a comma in it, you can type a double comma (,,) to insert a literal comma - this works in either a token name or a token value. Again, make certain that your list of token NAMES perfectly match the names of the tokens defined in the message within Pro6 - Pro6 won't crash if they match perfectly - so be carefull!
+Show&nbsp;Message | Shows the message on the stage display output. You can pass values for message tokens, but you must do so very carefully - a typo here can crash ProPresenter.  Crashes can cause data loss, and ruin your setup. Learn how to correctly enter message tokens by reading below. Always type carefully and double-check. Get it right on a test machine first! The correct way to pass values for message tokens is as two lists. The two lists work together to form token NAME and token VALUE pairs.  The first list is a comma-separated list of token NAMES and the second is a comma-separated list of token VALUES. The number of items in each list should match - e.g. if you supply two token NAMES, then you should supply two token VALUES to make matching pairs. All token names in your list *MUST* match the token names defined in the message within ProPresenter (or else Pro6 will likely crash).  The token values can be any text. You don't have to pass *all* the token names/values pairs - any name/values that you don't include will be treated as and displayed as blank. You don't have to pass any token names/values if you don't need to. Static messages without any tokens are safe - you can't make a typo if you leave the token names and token values list blank! If one of your token names or token values needs to have a comma in it, you can type a double comma (,,) to insert a literal comma - this works in either a token name or a token value. Again, make certain that your list of token NAMES perfectly match the names of the tokens defined in the message within Pro6 - Pro6 won't crash if they match perfectly - so be careful!
 Hide&nbsp;Message | Removes a message from output screen.
 
 Messages are identified by Index. Index is a 0-based, where the first message is 0, and then count up through the messages in the order shown in the list of ProPresenter messages.
@@ -108,9 +108,9 @@ Command | Description
 ------- | -----------
 Stage&nbsp;Display&nbsp;Message | Shows the message on the stage display output
 Stage&nbsp;Display&nbsp;Hide&nbsp;Message | Removes the stage display message
-Stage&nbsp;Display&nbsp;Layout | Sets the stage display layout. 
+Stage&nbsp;Display&nbsp;Layout | Sets the stage display layout.
 
-Stage Displays are indentified by index. Index is a 0-based number, where the first layout is 0 and then count up through the stage display layouts in the order shown in ProPresenters list of stage display layouts.
+Stage Displays are identified by index. Index is a 0-based number, where the first layout is 0 and then count up through the stage display layouts in the order shown in ProPresenters list of stage display layouts.
 
 
 ## Clocks (Timers)
@@ -119,7 +119,7 @@ Command | Description
 Start&nbsp;Clock | Starts clock (timer) - identified by index (0 based)
 Stop&nbsp;Clock | Stops clock (timer) - identified by index (0 based)
 Reset&nbsp;Clock | Resets clock (timer) - identified by index (0 based)
-Update&nbsp;Clock | Update clock/timer with a new duration - identified by index (0 based). You must specify the type of clock as either Count Down Timer, Count Down To Time or Elapsed Time. (Note that any clock you update will be changed to the the selected type.)  "Duration" is the new duration value for the count-down timer in the format HH:MM:SS. (It is also the starting time for Elapsed Time clocks. You may also use a shorthand format if you like. You can, if you want, leave out the HH and/or the MM values and they will default to zero - you can also leave out one or both of the ":" to enter just mins and/or seconds.  You can control overrun for all clock types.  AM/PM is only needed for Count Down To Time clocks.
+Update&nbsp;Clock | Update clock/timer with a new duration - identified by index (0 based). You must specify the type of clock as either Countdown Timer, Countdown To Time or Elapsed Time. (Note that any clock you update will be changed to the the selected type.)  "Duration" is the new duration value for the count-down timer in the format HH:MM:SS. (It is also the starting time for Elapsed Time clocks. You may also use a shorthand format if you like. You can, if you want, leave out the HH and/or the MM values and they will default to zero - you can also leave out one or both of the ":" to enter just mins and/or seconds.  You can control overrun for all clock types.  AM/PM is only needed for Countdown To Time clocks.
 
 **Tip: One-Touch Preset CountDown Timers.**
 If you use a lot of timers with commonly used values for duration, you might like to setup a few buttons that automatically reset and restart a count-down timer for your most commonly used durations. To make a single button do that for you, you can chain together the following three actions:
@@ -132,8 +132,8 @@ Use *relative delays*, to ensure these three action arrive in the correct order 
 ## Timeline
 Command | Description
 ------- | -----------
-Timeline&nbsp;Play/Pause | Toggle play/paused state of timeline for a specific presentation (See PresenationPath explanation above)
-Timeline&nbsp;Rewind  | Rewind timeline for a specific presentation (See PresenationPath explanation above)
+Timeline&nbsp;Play/Pause | Toggle play/paused state of timeline for a specific presentation (See PresentationPath explanation above)
+Timeline&nbsp;Rewind  | Rewind timeline for a specific presentation (See PresentationPath explanation above)
 
 Please Note: There is NO direct feedback from ProPresenter for when a timeline is playing or paused - so this cannot be shown to users on the StreamDeck!
 

--- a/HELP.md
+++ b/HELP.md
@@ -24,7 +24,7 @@ You can control ProPresenter on any computer within the same network, you just n
 
 If you want to connect to ProPresenter on the *same* computer that you are running Companion on, you can use the special looback IP address of 127.0.0.1 (which is the default setting)
 
-If the computers running ProPresenter and Companion have a choice of using either a wireless or a wired network connection, then it is recommended to always use wired. This is because a wired network connection is *typically* more reliable and has better latency (which is better for remote control).
+If the computers running ProPresenter and Companion are separate computers and they have the option of using either a wireless or a wired network connection, then it is recommended to use a wired network connection whenever possible. This is because a wired network connection is *typically* more reliable and has better latency - which is good for remote control.
 
 ## Configure the ProPresenter module in Companion
 Now you have all the info you need to go to the ProPresenter Companion module configuration and enter the IP address of the computer running ProPresenter as well as the ProPresenter port number and controller password that you took note of from ProPresenter network preferences.

--- a/HELP.md
+++ b/HELP.md
@@ -1,6 +1,8 @@
 # Companion-module: ProPresenter6
 
-Module for using ProPresenter 6 with the Elgato Stream Deck and Companion. Requires a network connection to ProPresenter via it's Remote network port.  Optionally, you can also configure a connection to the Stage Display App port if you want to track the Video CountDown Timer for any video that is playing.
+Module for using ProPresenter 6 with the Elgato Stream Deck and Companion. Requires a network connection to ProPresenter via it's Remote network port.
+
+*Optionally, you can also configure a connection to the Stage Display App port if you want to track the Video CountDown Timer for any video that is playing.*
 
 # Setup Guide.
 ## Enable networking in ProPresenter if you haven't already done so... 

--- a/HELP.md
+++ b/HELP.md
@@ -4,7 +4,7 @@ Module for using ProPresenter 6 with the Elgato Stream Deck and Companion. Requi
 
 # Setup Guide.
 ## Enable networking in ProPresenter if you haven't already done so... 
-1. Open ProPresenter and then click to open the "ProPresenter 6" Menu
+1. Open ProPresenter and then open the "ProPresenter 6" Menu.
 2. Select "Preferences..." to open the ProPresenter Preferences window.
 3. Select the Network tab to configure ProPresenter network preferences.
 4. Check the "Enable Network" option (if it is not already enabled).

--- a/HELP.md
+++ b/HELP.md
@@ -1,13 +1,13 @@
-# Companion-module: ProPresenter6
+# Companion-module: ProPresenter6/7
 
 
-Module for using ProPresenter 6 with the Elgato Stream Deck and Companion. Requires a network connection to ProPresenter via it's Remote network port.
+Module for using ProPresenter 6 or 7 with the Elgato Stream Deck and Companion. Requires a network connection to ProPresenter via it's Remote network port.
 
 *Optionally, you can also configure a connection to the Stage Display App port if you want to track the Video CountDown Timer for any video that is playing.*
 
 # Setup Guide.
 ## Enable networking in ProPresenter if you haven't already done so...
-1. Open ProPresenter and then open the "ProPresenter 6" Menu.
+1. Open ProPresenter and then open the "ProPresenter (6)" Menu.
 2. Select "Preferences..." to open the ProPresenter Preferences window.
 3. Select the Network tab to configure ProPresenter network preferences.
 4. Check the "Enable Network" option (if it is not already enabled).

--- a/HELP.md
+++ b/HELP.md
@@ -111,7 +111,8 @@ Stage&nbsp;Display&nbsp;Message | Shows the message on the stage display output
 Stage&nbsp;Display&nbsp;Hide&nbsp;Message | Removes the stage display message
 Stage&nbsp;Display&nbsp;Layout | Sets the stage display layout.
 
-Stage Displays are identified by index. Index is a 0-based number, where the first layout is 0 and then count up through the stage display layouts in the order shown in ProPresenters list of stage display layouts.
+In Pro6 Stage Displays are identified by index. Index is a 0-based number, where the first layout is 0 and then count up through the stage display layouts in the order shown in ProPresenters list of stage display layouts.
+In Pro7 you can choose which screen and which stage display layout you want to set by name. (The dropdown list of name is NOT refreshed until after you have connected to PRo7).
 
 
 ## Clocks (Timers)
@@ -149,3 +150,4 @@ $(propresenter:watched_clock_current_time) | In the config of this module, you c
 $(propresenter:current_stage_display_index) | Index of the currently selected stage display layout (This is updated whenever a new layout is selected.)
 $(propresenter:current_stage_display_name) | Name of the currently selected stage display layout (This is updated whenever a new layout is selected.)
 $(propresenter:video_countdown_timer) | Current value of video countdown timer - automatically updated when a video is playing. (This one variable is only updated when the module is configured to also connect to the Stage Display App port)
+$(propresenter:current_pro7_stage_layout_name) | The name of the current stage-display layout on the selected stage-display screen (as set in module config)

--- a/HELP.md
+++ b/HELP.md
@@ -1,6 +1,31 @@
-# companion-module-propresenter6
+# Companion-module: ProPresenter6
 
-Module for using ProPresenter with the Elgato Stream Deck and Companion. Requires a connection to the ProPresenter Remote network port.  Optionally, you can also configure a connection to the Stage Display App port if you want to track the Video CountDown Timer for any video that is playing.
+Module for using ProPresenter 6 with the Elgato Stream Deck and Companion. Requires a network connection to ProPresenter via it's Remote network port.  Optionally, you can also configure a connection to the Stage Display App port if you want to track the Video CountDown Timer for any video that is playing.
+
+# Setup Guide.
+## Enable networking in ProPresenter if you haven't already done so... 
+1. Open ProPresenter and then click to open the "ProPresenter 6" Menu
+2. Select "Preferences..." to open the ProPresenter Preferences window.
+3. Select the Network tab to configure ProPresenter network preferences.
+4. Check the "Enable Network" option (if it is not already enabled).
+5. Check the "Enable ProPresenter Remote" option (if it is not already enabled).
+6. Check the "Controller" option (if it is not already enabled).
+7. Enter a controller password (or take note of the existing controller password).
+8. Take a note of the Port number (to the right of the Network Name) - this is typically 4-5 digits.
+9. If you would like your StreamDeck to be able to display "Video CountDown" timers, then you will also need to check the option for "Enable Stage Display App" and enter (or take note of the existing) password.
+9. Close ProPresenter preferences window.
+
+## Get the IP address of the computer running ProPresenter
+Use your knowledge of networking (or Google) to get the IP address of the computer running ProPresenter.
+Tip: You can control ProPresenter on any computer within the same network, you just need to know the IP address. If you want to connect to ProPresenter on the *same* computer that you are running Companion on, you can use the special looback IP address of 127.0.0.1
+If your ProPresenter (and Companion) computers have a choice of using either wireless or a wired connection, go for wired as a wired network connection is *typically* more reliable and has better latency - which is what you want when doing remote control!
+
+## Configure the ProPresenter module in Companion
+Goto the module config and enter the IP address of the computer running ProPresenter.
+Enter the port number and password that you took note of from ProPresenter network preferences.
+If you chose to also enable the stage display app option in ProPresenter preferences (so your StreamDeck can display "Video Countdown" timers, then you can also select "Yes" for the configuration field "Connect to StageDisplay (Only required for video countdown timer)" and enter the stage display password.
+N.B. At the time of writing this module, there is a bug in ProPresenter 6 where if you choose to enter a Port number for the stage display app - it will actually ingore it and use the "main" network port you recorded in step 8 above.
+
 
 # Commands
 ## Slides

--- a/HELP.md
+++ b/HELP.md
@@ -25,9 +25,10 @@ If you want to connect to ProPresenter on the *same* computer that you are runni
 If your ProPresenter (and Companion) computers have a choice of using either wireless or a wired connection, always use wired, as a wired network connection is *typically* more reliable and has better latency (good for remote control).
 
 ## Configure the ProPresenter module in Companion
-Goto the module config and enter the IP address of the computer running ProPresenter.
-Enter the port number and password that you took note of from ProPresenter network preferences.
+Now you have all the info you need to go to the ProPresenter Companion module configuration and enter the IP address of the computer running ProPresenter as well as the ProPresenter port number and controller password that you took note of from ProPresenter network preferences.
+
 If you chose to also enable the stage display app option in ProPresenter preferences (so your StreamDeck can display "Video Countdown" timers) then you can also select "Yes" for the configuration field "Connect to StageDisplay (Only required for video countdown timer)" and enter the stage display password.
+
 N.B. At the time of writing this module, there is a bug in ProPresenter 6 where if you choose to enter a Port number for the stage display app - it will actually ingore it and use the "main" network port you recorded in step 8 above.
 
 

--- a/index.js
+++ b/index.js
@@ -855,11 +855,11 @@ instance.prototype.actions = function(system) {
 				},
 				{
 					type: 'dropdown',
-					label: 'Clock Is PM',
-					id: 'clockIsPM',
+					label: 'Clock Time Format',
+					id: 'clockTimePeriodFormat',
 					default: '0',
 					tooltip: 'Only Required for Countdown To Time Clock - otherwise this is ignored.',
-					choices: [ { id: '0', label: 'No' }, { id: '1', label: 'Yes' } ]
+					choices: [ { id: '0', label: 'AM' }, { id: '1', label: 'PM' }, { id: '2', label: '24Hr (Pro7 Only)' } ]
 				},
 				{
 					type: 'textinput',
@@ -1133,7 +1133,8 @@ instance.prototype.action = function(action) {
 				clockTime: opt.clockTime,
 				clockOverrun: opt.clockOverRun,
 				clockType: opt.clockType,
-				clockIsPM: opt.clockIsPM,
+				clockIsPM: opt.clockTimePeriodFormat < 2 ? opt.clockTimePeriodFormat : 2, // Pro6 just wants a 1 (PM) or 0 (AM)
+				clockTimePeriodFormat: opt.clockTimePeriodFormat, 
 				clockElapsedTime: opt.clockElapsedTime,
 				clockName: opt.clockName
 			};
@@ -1352,11 +1353,13 @@ instance.prototype.onWebSocketMessage = function(message) {
 			break;
 
 		case 'stageDisplaySetIndex': // Companion User (or someone else) has set a new Stage Display Layout in Pro6 (Time to refresh stage display dynamic variables)
-			var stageDisplayIndex = objData.stageDisplayIndex;
-			self.currentState.internal.stageDisplayIndex = parseInt(stageDisplayIndex,10);
-			self.updateVariable('current_stage_display_index', stageDisplayIndex);
-			self.getStageDisplaysInfo();
-			self.checkFeedbacks('stagedisplay_active');
+			if (self.currentState.internal.proMajorVersion === 6) {
+				var stageDisplayIndex = objData.stageDisplayIndex;
+				self.currentState.internal.stageDisplayIndex = parseInt(stageDisplayIndex,10);
+				self.updateVariable('current_stage_display_index', stageDisplayIndex);
+				self.getStageDisplaysInfo();
+				self.checkFeedbacks('stagedisplay_active');
+			}
 			break;
 
 		case 'stageDisplaySets':  // The response from sending stageDisplaySets is a reply that includes an array of Stage Display Layout Names, and also stageDisplayIndex set to the index of the currently selected layout

--- a/index.js
+++ b/index.js
@@ -445,7 +445,7 @@ instance.prototype.startConnectionTimer = function() {
 			self.connectToProPresenter();
 		}
 
-	}, 5000);
+	}, 1000);
 
 };
 
@@ -1007,7 +1007,7 @@ instance.prototype.action = function(action) {
 
 			cmd = {
 				action: "presentationTriggerIndex",
-				slideIndex: index,
+				slideIndex: String(index),
 				// Pro 6 for Windows requires 'presentationPath' to be set.
 				presentationPath: presentationPath
 			};
@@ -1058,7 +1058,7 @@ instance.prototype.action = function(action) {
 		case 'stageDisplayLayout':
 			cmd = {
 				action: "stageDisplaySetIndex",
-				stageDisplayIndex: opt.index
+				stageDisplayIndex: String(opt.index)
 			};
 			break;
 			
@@ -1086,7 +1086,7 @@ instance.prototype.action = function(action) {
 			break;
 
 		case 'clockStart':
-			var clockIndex = parseInt(opt.clockIndex);
+			var clockIndex = String(opt.clockIndex);
 			cmd = {
 				action: "clockStart",
 				clockIndex: clockIndex
@@ -1094,7 +1094,7 @@ instance.prototype.action = function(action) {
 			break;
 
 		case 'clockStop':
-			var clockIndex = parseInt(opt.clockIndex);
+			var clockIndex = String(opt.clockIndex);
 			cmd = {
 				action: "clockStop",
 				clockIndex: clockIndex
@@ -1102,7 +1102,7 @@ instance.prototype.action = function(action) {
 			break;
 
 		case 'clockReset':
-			var clockIndex = parseInt(opt.clockIndex);
+			var clockIndex = String(opt.clockIndex);
 			cmd = {
 				action: "clockReset",
 				clockIndex: clockIndex
@@ -1110,7 +1110,7 @@ instance.prototype.action = function(action) {
 			break;
 
 		case 'clockUpdate':
-			var clockIndex = parseInt(opt.clockIndex);
+			var clockIndex = String(opt.clockIndex);
 
 			// Protect against option values which may be missing if this action is called from buttons that were previously saved before these options were added to the clockUpdate action!
 			// If they are missing, then apply default values that result in the oringial bahaviour when it was only updating a countdown timers clockTime and clockOverRun.
@@ -1133,8 +1133,8 @@ instance.prototype.action = function(action) {
 				clockTime: opt.clockTime,
 				clockOverrun: opt.clockOverRun,
 				clockType: opt.clockType,
-				clockIsPM: opt.clockTimePeriodFormat < 2 ? opt.clockTimePeriodFormat : 2, // Pro6 just wants a 1 (PM) or 0 (AM)
-				clockTimePeriodFormat: opt.clockTimePeriodFormat, 
+				clockIsPM: String(opt.clockTimePeriodFormat) < 2 ? String(opt.clockTimePeriodFormat) : '2', // Pro6 just wants a 1 (PM) or 0 (AM)
+				clockTimePeriodFormat: String(opt.clockTimePeriodFormat), 
 				clockElapsedTime: opt.clockElapsedTime,
 				clockName: opt.clockName
 			};
@@ -1143,7 +1143,7 @@ instance.prototype.action = function(action) {
 		case 'messageHide':
 			cmd = {
 				action: "messageHide",
-				messageIndex: opt.messageIndex
+				messageIndex: String(opt.messageIndex)
 			};
 			break;
 
@@ -1153,7 +1153,7 @@ instance.prototype.action = function(action) {
 			// Note that character 28 and 29 are not "normally typed characters" and therefore considered (somewhat) safe to insert into the string as special markers during processing. Also note that CharCode(29) is matched by regex /\u001D/
 			cmd = {
 				action: "messageSend",
-				messageIndex: opt.messageIndex,
+				messageIndex: String(opt.messageIndex),
 				messageKeys: opt.messageKeys.replace(/,,/g, String.fromCharCode(29)).replace(/,/g, String.fromCharCode(28)).replace(/\u001D/g, ',').split(String.fromCharCode(28)),
 				messageValues: opt.messageValues.replace(/,,/g, String.fromCharCode(29)).replace(/,/g, String.fromCharCode(28)).replace(/\u001D/g, ',').split(String.fromCharCode(28))
 			};
@@ -1252,6 +1252,7 @@ instance.prototype.onWebSocketMessage = function(message) {
 	var self = this;
 	var objData;
 	try {
+		self.log('info', message); // TODO: remove this (or wrap in high-level debug option)
 		objData = JSON.parse(message);
 	} catch (err) {
 		self.log('warn', err.message);
@@ -1436,8 +1437,10 @@ instance.prototype.onSDWebSocketMessage = function(message) {
 			break;
 
 		case 'vid':
-			// Record new video countdown timer value in dynamic var
-			self.updateVariable('video_countdown_timer', objData.txt);
+			if (objData.hasOwnProperty('txt')) {
+				// Record new video countdown timer value in dynamic var
+				self.updateVariable('video_countdown_timer', objData.txt);
+			}
 			break;
 
 	}
@@ -1456,7 +1459,7 @@ instance.prototype.getProPresenterState = function() {
 
 	self.socket.send(JSON.stringify({
 		action: 'presentationCurrent',
-		presentationSlideQuality: 0 // Setting to 0 stops Pro6 from including the slide preview image data (which is a lot of data) - no need to get slide preview images since we are not using them!
+		presentationSlideQuality: '0' // Setting to 0 stops Pro6 from including the slide preview image data (which is a lot of data) - no need to get slide preview images since we are not using them!
 	}));
 
 	if (self.currentState.dynamicVariables.current_slide === 'N/A') {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 		"propresenter6",
 		"propresenter"
 	],
-	"version": "2.2.0",
+	"version": "2.3.0",
 	"api_version": "1.0.0",
 	"keywords": [
 		"Software",


### PR DESCRIPTION
Pro7 is very new - and there will likely be some changes over next few months.
This module has been tested working with Pro7 and Pro6 on both Win10 and MacOS Mojave.
I plan to update some more features - such as tracking timers by name and allow user to select with dropdown. However, this module is ready to share with users and start getting feedback for any issues.

Overview of changes:
Updated to connect and authenticate with Pro7.
Some messages have change format and required conditional processing.
Added some action for selecting stage display layouts on any stage screen in Pro7.
Added new dynamic variable to watch stage display layout of a selected stage screen (in config).
Added some tidy up (logging, error handling)
Matched some types (int/string) for action parameters (to match what current remote app sends).
Update Help.md