### PR TITLE
Added option to turn off a feature that is causing pro7 performance issues…

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -34,6 +34,9 @@ If you chose to also enable the stage display app option in ProPresenter prefere
 
 N.B. At the time of writing this module, there is a bug in ProPresenter 6 where if you choose to enter a Port number for the stage display app - it will actually ignore it and use the "main" network port you recorded in step 8 above.
 
+Pro7 users:  Currently there is a noticeable performance impact within ProPresenter 7 itself when companion sends messages to Pro7 to track info about the current presentation.
+To work around this, there is now a new option called "Send Presentation Info Requests To ProPresenter" in the module configuration where you can optionally turn that off.  Doing so will remove the performance impact (random lag when changing slides) but will stop updating the dynamic variables: remaining_slides, total_slides or presentation_name.  You will no longer be able to display them on buttons. We will continue to investigate a fix with RenewedVision (or a better workaround).
+
 
 # Commands
 ## Slides

--- a/index.js
+++ b/index.js
@@ -82,6 +82,15 @@ instance.prototype.config_fields = function () {
 			choices: self.currentState.internal.pro7StageScreens
 		},
 		{
+			type: 'dropdown',
+			id: 'sendPresentationCurrentMsgs',
+			label: 'Send Presentation Info Requests To ProPresenter',
+			tooltip: 'You may want to turn this off for Pro7 as it can cause performance issues - Turning it off will mean the module does not update the dynamic variables: remaining_slides, total_slides or presentation_name',
+			default: 'yes',
+			width: 6,
+			choices: [ { id: 'no', label: 'No' }, { id: 'yes', label: 'Yes' } ]
+		},
+		{
 			type: 'text',
 			id: 'info',
 			width: 12,
@@ -1479,11 +1488,12 @@ instance.prototype.getProPresenterState = function() {
 	if (self.currentState.internal.wsConnected === false) {
 		return;
 	}
-
-	self.socket.send(JSON.stringify({
-		action: 'presentationCurrent',
-		presentationSlideQuality: '0' // Setting to 0 stops Pro6 from including the slide preview image data (which is a lot of data) - no need to get slide preview images since we are not using them!
-	}));
+	if (self.config.sendPresentationCurrentMsgs !== 'no') { // User can optionally block sending these msgs to ProPresenter (as it can cause performance issues with Pro7)
+		self.socket.send(JSON.stringify({
+			action: 'presentationCurrent',
+			presentationSlideQuality: '0' // Setting to 0 stops Pro6 from including the slide preview image data (which is a lot of data) - no need to get slide preview images since we are not using them!
+		}));
+		}
 
 	if (self.currentState.dynamicVariables.current_slide === 'N/A') {
 		// The currentSlide will be empty when the module first loads. Request it.


### PR DESCRIPTION
Currently there is a noticeable performance impact within ProPresenter 7 itself when companion sends messages to Pro7 to track info about the current presentation.
To work around this, there is now a new option called "Send Presentation Info Requests To ProPresenter" in the module configuration where you can optionally turn that off.  Doing so will remove the performance impact (random lag when changing slides) but will stop updating the dynamic variables: remaining_slides, total_slides or presentation_name.  You will no longer be able to display them on buttons. We will continue to investigate a fix with RenewedVision (or a better workaround).