### PR TITLE
Quick fix to workaround crash in Pro7

### DIFF
--- a/index.js
+++ b/index.js
@@ -1086,10 +1086,11 @@ instance.prototype.action = function(action) {
 			break;
 			
 		case 'pro7StageDisplayLayout':
+			// If either option is null, then default to using first items from each list kept in internal state.
 			cmd = {
 				action: "stageDisplayChangeLayout",
-				stageScreenUUID: opt.pro7StageScreenUUID,
-				stageLayoutUUID: opt.pro7StageLayoutUUID,
+				stageScreenUUID: opt.pro7StageScreenUUID ? opt.pro7StageScreenUUID : self.currentState.internal.pro7StageScreens[0].id,
+				stageLayoutUUID: opt.pro7StageLayoutUUID ? opt.pro7StageLayoutUUID : self.currentState.internal.pro7StageLayouts[0].id,
 			};
 			break;
 


### PR DESCRIPTION
Pro7 will crash when sent messages to set stagedisplay layout if either selected screen or stage layout is null.
This update checks for null and sets default value if so (default will be first item in list of screens and layouts kept in internal state)