### PR TITLE
Alternative labels for countdown clock presets for when indexOfClockToWatch is undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,6 +131,7 @@ instance.prototype.config_fields = function () {
 instance.prototype.updateConfig = function(config) {
 	var self = this;
 	self.config = config;
+    self.init_presets();
 	self.disconnectFromProPresenter();
 	self.disconnectFromProPresenterSD();
 	self.connectToProPresenter();
@@ -187,9 +188,8 @@ instance.prototype.destroy = function() {
 */
 instance.prototype.init_presets = function () {
 	var self = this;
-    var clockTitle = typeof self.config.indexOfClockToWatch !== 'undefined' ? 'Clock '+ self.config.indexOfClockToWatch : '';
-	
-    var presets = [
+
+	var presets = [
 		{
 			category: 'Stage Display',
 			label: 'This button displays the name of current stage display layout. Pressing it will toggle back and forth between the two selected stage display layouts in the down and up actions.',
@@ -242,7 +242,7 @@ instance.prototype.init_presets = function () {
 			label: 'This button will reset a selected (by index) clock to a 5 min countdown clock and automatically start it.',
 			bank: {
 				style: 'text',
-				text: (clockTitle=='' ? 'Clock' : clockTitle) +'\\n5 mins',
+				text: 'Clock '+self.config.indexOfClockToWatch+'\\n5 mins',
 				size: '18',
 				color: self.rgb(255,255,255),
 				bgcolor: self.rgb(0,153,51)
@@ -278,7 +278,7 @@ instance.prototype.init_presets = function () {
 			label: 'This button will START a clock selected by index (0-based). If you change the index, and still want to display the current time on the button, make sure to also update the index of the clock to watch in this modules config to match.',
 			bank: {
 				style: 'text',
-				text: 'Start\\n'+clockTitle+'\\n$(propresenter:watched_clock_current_time)',
+				text: 'Start\\nClock '+self.config.indexOfClockToWatch+'\\n$(propresenter:watched_clock_current_time)',
 				size: '14',
 				color: self.rgb(255,255,255),
 				bgcolor: self.rgb(0,153,51)
@@ -297,7 +297,7 @@ instance.prototype.init_presets = function () {
 			label: 'This button will STOP a clock selected by index (0-based). If you change the index, and still want to display the current time on the button, make sure to also update the index of the clock to watch in this modules config to match.',
 			bank: {
 				style: 'text',
-				text: 'Stop\\n '+clockTitle+'\\n$(propresenter:watched_clock_current_time)',
+				text: 'Stop\\nClock '+self.config.indexOfClockToWatch+'\\n$(propresenter:watched_clock_current_time)',
 				size: '14',
 				color: self.rgb(255,255,255),
 				bgcolor: self.rgb(204,0,0)
@@ -316,7 +316,7 @@ instance.prototype.init_presets = function () {
 			label: 'This button will RESET a clock selected by index (0-based). If you change the index, and still want to display the current time on the button, make sure to also update the index of the clock to watch in this modules config to match.',
 			bank: {
 				style: 'text',
-				text: 'Reset\\n '+clockTitle+'\\n$(propresenter:watched_clock_current_time)',
+				text: 'Reset\\nClock '+self.config.indexOfClockToWatch+'\\n$(propresenter:watched_clock_current_time)',
 				size: '14',
 				color: self.rgb(255,255,255),
 				bgcolor: self.rgb(255,102,0)

--- a/index.js
+++ b/index.js
@@ -187,8 +187,9 @@ instance.prototype.destroy = function() {
 */
 instance.prototype.init_presets = function () {
 	var self = this;
-
-	var presets = [
+    var clockTitle = typeof self.config.indexOfClockToWatch !== 'undefined' ? 'Clock '+ self.config.indexOfClockToWatch : '';
+	
+    var presets = [
 		{
 			category: 'Stage Display',
 			label: 'This button displays the name of current stage display layout. Pressing it will toggle back and forth between the two selected stage display layouts in the down and up actions.',
@@ -241,7 +242,7 @@ instance.prototype.init_presets = function () {
 			label: 'This button will reset a selected (by index) clock to a 5 min countdown clock and automatically start it.',
 			bank: {
 				style: 'text',
-				text: 'Clock '+self.config.indexOfClockToWatch+'\\n5 mins',
+				text: (clockTitle=='' ? 'Clock' : clockTitle) +'\\n5 mins',
 				size: '18',
 				color: self.rgb(255,255,255),
 				bgcolor: self.rgb(0,153,51)
@@ -277,7 +278,7 @@ instance.prototype.init_presets = function () {
 			label: 'This button will START a clock selected by index (0-based). If you change the index, and still want to display the current time on the button, make sure to also update the index of the clock to watch in this modules config to match.',
 			bank: {
 				style: 'text',
-				text: 'Start\\nClock '+self.config.indexOfClockToWatch+'\\n$(propresenter:watched_clock_current_time)',
+				text: 'Start\\n'+clockTitle+'\\n$(propresenter:watched_clock_current_time)',
 				size: '14',
 				color: self.rgb(255,255,255),
 				bgcolor: self.rgb(0,153,51)
@@ -296,7 +297,7 @@ instance.prototype.init_presets = function () {
 			label: 'This button will STOP a clock selected by index (0-based). If you change the index, and still want to display the current time on the button, make sure to also update the index of the clock to watch in this modules config to match.',
 			bank: {
 				style: 'text',
-				text: 'Stop\\nClock '+self.config.indexOfClockToWatch+'\\n$(propresenter:watched_clock_current_time)',
+				text: 'Stop\\n '+clockTitle+'\\n$(propresenter:watched_clock_current_time)',
 				size: '14',
 				color: self.rgb(255,255,255),
 				bgcolor: self.rgb(204,0,0)
@@ -315,7 +316,7 @@ instance.prototype.init_presets = function () {
 			label: 'This button will RESET a clock selected by index (0-based). If you change the index, and still want to display the current time on the button, make sure to also update the index of the clock to watch in this modules config to match.',
 			bank: {
 				style: 'text',
-				text: 'Reset\\nClock '+self.config.indexOfClockToWatch+'\\n$(propresenter:watched_clock_current_time)',
+				text: 'Reset\\n '+clockTitle+'\\n$(propresenter:watched_clock_current_time)',
 				size: '14',
 				color: self.rgb(255,255,255),
 				bgcolor: self.rgb(255,102,0)


### PR DESCRIPTION
Give alternative labels for countdown clock presets for when `indexOfClockToWatch` is `undefined`

When you first add an instance of ProPresenter to Companion, if you don't restart Companion before adding a preset button self.config.indexOfClockToWatch is undefined

With this fix, for the first preset instead of "Clock \n undefined \n 5 mins" It now says "Clock \n 5 mins"
For the other three presets (Start, Stop, Reset) instead of "Start \n Clock \n undefined" it says "Start \n\n 00:00:00"

After resetting Companion the the presets will look exactly as they did before this change