### PR TITLE
Crash Bug Fix: Websocket connection attempts with invalid URLs

### DIFF
--- a/index.js
+++ b/index.js
@@ -607,8 +607,8 @@ instance.prototype.disconnectFromProPresenterSD = function() {
 instance.prototype.connectToProPresenter = function() {
 	var self = this;
 
-	// ~~ is a double NOT bitwise operator. It will change port to a numeric value of 0 if it is null, undefined or "".
-	if (self.config.host === undefined || ~~self.config.port === 0) {
+	// Check for undefined host or port. Also make sure port is [1-65535] and host is least 1 char long.
+	if (!self.config.host || self.config.host.length<1 || !self.config.port || self.config.port<1 || self.config.port>65535) {
 		// Do not try to connect with invalid host or port
 		return;
 	}
@@ -670,8 +670,8 @@ instance.prototype.connectToProPresenter = function() {
 instance.prototype.connectToProPresenterSD = function() {
 	var self = this;
 
-	// ~~ is a double NOT bitwise operator. It will change port to a numeric value of 0 if it is null, undefined or "".
-	if (self.config.host === undefined || ~~self.config.port === 0) {
+	// Check for undefined host or port. Also make sure port is [1-65535] and host is least 1 char long.
+	if (!self.config.host || self.config.host.length<1 || !self.config.port || self.config.port<1 || self.config.port>65535) {
 		// Do not try to connect with invalid host or port
 		return;
 	}
@@ -683,8 +683,8 @@ instance.prototype.connectToProPresenterSD = function() {
 		return;
 	}
 
-	// Use ProPresenter remote control port if stage display port is not set. (~~ is a double NOT bitwise operator. It will change sdport to a numeric value of 0 if it is null, undefined or "".)
-	if (~~self.config.sdport === 0) {
+	// Check for undefined sdport. Also make sure sdport is [1-65535]. (Otherwise, use ProPresenter remote port)
+	if (!self.config.sdport || self.config.sdport<1 || self.config.sdport>65535) {
 		self.config.sdport = self.config.port;
 	}
 

--- a/index.js
+++ b/index.js
@@ -683,8 +683,8 @@ instance.prototype.connectToProPresenterSD = function() {
 		return;
 	}
 
-	// Use ProPresenter remote control port if stage display port is not set.
-	if (self.config.sdport === '') {
+	// Use ProPresenter remote control port if stage display port is not set. (~~ is a double NOT bitwise operator. It will change sdport to a numeric value of 0 if it is null, undefined or "".)
+	if (~~self.config.sdport === 0) {
 		self.config.sdport = self.config.port;
 	}
 

--- a/index.js
+++ b/index.js
@@ -643,7 +643,7 @@ instance.prototype.connectToProPresenter = function() {
 		var wasConnected = self.currentState.internal.wsConnected;
 
 
-		self.log('warn', 'socket closed');
+		self.log('info', 'socket closed');
 
 		self.emptyCurrentState();  // This is also sets self.currentState.internal.wsConnected to false
 

--- a/index.js
+++ b/index.js
@@ -158,10 +158,10 @@ instance.prototype.init = function() {
 
 	if (self.config.host !== '' && self.config.port !== '') {
 		self.connectToProPresenter();
-		self.connectToProPresenterSD();
 		self.startConnectionTimer();
 		if (self.config.use_sd === 'yes') {
 			self.startSDConnectionTimer();
+			self.connectToProPresenterSD();
 		}
 	}
 
@@ -607,13 +607,14 @@ instance.prototype.disconnectFromProPresenterSD = function() {
 instance.prototype.connectToProPresenter = function() {
 	var self = this;
 
-	// Disconnect if already connected
-	self.disconnectFromProPresenter();
-
-	// ~~ is a double NOT bitwise operator. Will change .port to a numeric value, including null, undefined, "" to 0.
+	// ~~ is a double NOT bitwise operator. It will change port to a numeric value of 0 if it is null, undefined or "".
 	if (self.config.host === undefined || ~~self.config.port === 0) {
+		// Do not try to connect with invalid host or port
 		return;
 	}
+	
+	// Disconnect if already connected
+	self.disconnectFromProPresenter();
 
 	// Connect to remote control websocket of ProPresenter
 	self.socket = new WebSocket('ws://'+self.config.host+':'+self.config.port+'/remote');
@@ -668,6 +669,12 @@ instance.prototype.connectToProPresenter = function() {
  */
 instance.prototype.connectToProPresenterSD = function() {
 	var self = this;
+
+	// ~~ is a double NOT bitwise operator. It will change port to a numeric value of 0 if it is null, undefined or "".
+	if (self.config.host === undefined || ~~self.config.port === 0) {
+		// Do not try to connect with invalid host or port
+		return;
+	}
 
 	// Disconnect if already connected
 	self.disconnectFromProPresenterSD();


### PR DESCRIPTION
Fixed crash bug where module would try to connect to stage display websocket (or main remote websocket) with invalid URL through undefined module config values.  (Checks for undefined host or port config values - also perform simple validity checks on hostname and port when defined)