### PR TITLE
Add "Leader-Follower" Beta Feature

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -37,6 +37,8 @@ N.B. At the time of writing this module, there is a bug in ProPresenter 6 where 
 Pro7 users:  Currently there is a noticeable performance impact within ProPresenter 7 itself when companion sends messages to Pro7 to track info about the current presentation.
 To work around this, there is now a new option called "Send Presentation Info Requests To ProPresenter" in the module configuration where you can optionally turn that off.  Doing so will remove the performance impact (random lag when changing slides) but will stop updating the dynamic variables: remaining_slides, total_slides or presentation_name.  You will no longer be able to display them on buttons. We will continue to investigate a fix with RenewedVision (or a better workaround).
 
+## Optional (Beta) Leader-Follower Feature
+You can optionally configure a second connection to a "Follower" ProPresenter 7 computer to have the module automatically forward slide trigger and clears actions to the Follower as you click on slides (or use clear actions) on the main ProPresenter computer (The Leader).  This emulates the old Pro6 Master-Control module.  It's not complete as some actions cannot be captured by the module to forward to the Follower (the remote protocol does not send notifications for every action - but as it improves, this module will be updated).  For now basic slide triggers and some clear actions do work - This might be enough for some people (until RV introduce a new feature in Pro7 to do the same).
 
 # Commands
 ## Slides

--- a/index.js
+++ b/index.js
@@ -531,6 +531,8 @@ instance.prototype.startConnectionTimer = function() {
 		if (self.socket === undefined || self.socket.readyState === 3 /*CLOSED*/) {
 			// Not connected. Try to connect again.
 			self.connectToProPresenter();
+		} else {
+			self.currentState.internal.wsConnected = true;
 		}
 
 	}, 3000);
@@ -569,6 +571,8 @@ instance.prototype.startSDConnectionTimer = function() {
 		if (self.sdsocket === undefined || self.sdsocket.readyState === 3 /*CLOSED*/) {
 			// Not connected. Try to connect again.
 			self.connectToProPresenterSD();
+		} else {
+			self.currentState.internal.wsSDConnected = true;
 		}
 
 	}, 5000);
@@ -606,6 +610,8 @@ instance.prototype.startFollowerConnectionTimer = function() {
 		if (self.followersocket === undefined || self.followersocket.readyState === 3 /*CLOSED*/) {
 			// Not connected. Try to connect again.
 			self.connectToFollowerProPresenter();
+		} else {
+			self.currentState.internal.wsFollowerConnected = true;
 		}
 
 	}, 3000);

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ instance.prototype.config_fields = function () {
 			type: 'textinput',
 			id: 'pass',
 			label: 'ProPresenter Remote Password',
-			width: 8,
+			width: 6,
 		},
 		{
 			type: 'textinput',
@@ -99,7 +99,7 @@ instance.prototype.config_fields = function () {
 		},
 		{
 			type: 'dropdown',
-			label: 'Connect to Stage Display',
+			label: 'Connect to Stage Display?',
 			id: 'use_sd',
 			default: 'no',
 			width: 6,
@@ -119,7 +119,44 @@ instance.prototype.config_fields = function () {
 			type: 'textinput',
 			id: 'sdpass',
 			label: 'Stage Display App Password',
-			width: 8,
+			width: 6,
+		},
+		{
+			type: 'text',
+			id: 'info2',
+			width: 12,
+			label: 'Pro7 Follower Settings (Optional)',
+			value: "Optional *Beta* feature to mimic Pro6 Master-Control module"
+		},
+		{
+			type: 'dropdown',
+			label: 'Auto-Control Follower ProPresenter?',
+			id: 'control_follower',
+			default: 'no',
+			width: 6,
+			choices: [ { id: 'no', label: 'No' }, { id: 'yes', label: 'Yes' } ]
+		},
+		{
+			type: 'textinput',
+			id: 'followerhost',
+			label: 'Follower-ProPresenter IP',
+			width: 6,
+			default: '',
+			regex: self.REGEX_IP
+		},
+		{
+			type: 'textinput',
+			id: 'followerport',
+			label: 'Follower-ProPresenter Port',
+			width: 6,
+			default: '20652',
+			regex: self.REGEX_PORT
+		},
+		{
+			type: 'textinput',
+			id: 'followerpass',
+			label: 'Follower-ProPresenter Remote Password',
+			width: 6,
 		}
 	]
 };
@@ -142,6 +179,12 @@ instance.prototype.updateConfig = function(config) {
 	} else {
 		self.stopSDConnectionTimer();
 	}
+	if (self.config.control_follower === 'yes') {
+		self.connectToFollowerProPresenter();
+		self.startFollowerConnectionTimer();
+	} else {
+		self.stopFollowerConnectionTimer();
+	}
 };
 
 
@@ -162,6 +205,10 @@ instance.prototype.init = function() {
 		if (self.config.use_sd === 'yes') {
 			self.startSDConnectionTimer();
 			self.connectToProPresenterSD();
+		}
+		if (self.config.control_follower === 'yes') {
+			self.startFollowerConnectionTimer();
+			self.connectToFollowerProPresenter();
 		}
 	}
 
@@ -340,7 +387,7 @@ instance.prototype.init_presets = function () {
 instance.prototype.emptyCurrentState = function() {
 	var self = this;
 
-	self.log('info', 'emptyCurrentState');
+	self.log('debug', 'emptyCurrentState');
 
 	// Reinitialize the currentState variable, otherwise this variable (and the module's
 	//	state) will be shared between multiple instances of this module.
@@ -350,6 +397,7 @@ instance.prototype.emptyCurrentState = function() {
 	self.currentState.internal = {
 		wsConnected: false,
 		wsSDConnected: false,
+		wsFollowerConnected: false,
 		presentationPath: '-',
 		slideIndex: 0,
 		proMajorVersion: 6,  // Behaviour is slightly different between the two major versions of ProPresenter (6 & 7). Use this flag to run version-specific code where required. Default to 6 -  Pro7 can be detected once authenticated.
@@ -365,6 +413,7 @@ instance.prototype.emptyCurrentState = function() {
 		presentation_name: 'N/A',
 		connection_status: 'Disconnected',
 		sd_connection_status: 'Disconnected',
+		follower_connection_status: 'Disconnected',
 		video_countdown_timer: 'N/A',
 		watched_clock_current_time: 'N/A',
 		current_stage_display_name: 'N/A',
@@ -425,6 +474,10 @@ instance.prototype.initVariables = function() {
 		{
 			label: 'Video Countdown Timer',
 			name:  'video_countdown_timer'
+		},
+		{
+			label: 'Follower Connection Status',
+			name:  'follower_connection_status'
 		}
 	];
 
@@ -471,7 +524,7 @@ instance.prototype.startConnectionTimer = function() {
 	// Stop the timer if it was already running
 	self.stopConnectionTimer();
 
-	self.log('info', "Starting ConnectionTimer");
+	self.log('debug', "Starting ConnectionTimer");
 	// Create a reconnect timer to watch the socket. If disconnected try to connect.
 	self.reconTimer = setInterval(function() {
 
@@ -480,7 +533,7 @@ instance.prototype.startConnectionTimer = function() {
 			self.connectToProPresenter();
 		}
 
-	}, 1000);
+	}, 3000);
 
 };
 
@@ -491,7 +544,7 @@ instance.prototype.startConnectionTimer = function() {
 instance.prototype.stopConnectionTimer = function() {
 	var self = this;
 
-	self.log('info', "Stopping ConnectionTimer");
+	self.log('debug', "Stopping ConnectionTimer");
 	if (self.reconTimer !== undefined) {
 		clearInterval(self.reconTimer);
 		delete self.reconTimer;
@@ -510,7 +563,7 @@ instance.prototype.startSDConnectionTimer = function() {
 	self.stopSDConnectionTimer();
 
 	// Create a reconnect timer to watch the socket. If disconnected try to connect
-	self.log('info', "Starting SDConnectionTimer");
+	self.log('debug', "Starting SDConnectionTimer");
 	self.reconSDTimer = setInterval(function() {
 
 		if (self.sdsocket === undefined || self.sdsocket.readyState === 3 /*CLOSED*/) {
@@ -522,20 +575,58 @@ instance.prototype.startSDConnectionTimer = function() {
 
 };
 
-
 /**
  * Stops the stage display reconnection timer.
  */
 instance.prototype.stopSDConnectionTimer = function() {
 	var self = this;
 
-	self.log('info', "Stopping SDConnectionTimer");
+	self.log('debug', "Stopping SDConnectionTimer");
 	if (self.reconSDTimer !== undefined) {
 		clearInterval(self.reconSDTimer);
 		delete self.reconSDTimer;
 	}
 
 };
+
+
+/**
+ * Create a timer to connect to Follower ProPresenter.
+ */
+instance.prototype.startFollowerConnectionTimer = function() {
+	var self = this;
+
+	// Stop the timer if it was already running
+	self.stopFollowerConnectionTimer();
+
+	self.log('debug', "Starting Follower ConnectionTimer");
+	// Create a reconnect timer to watch the socket. If disconnected try to connect.
+	self.reconFollowerTimer = setInterval(function() {
+
+		if (self.followersocket === undefined || self.followersocket.readyState === 3 /*CLOSED*/) {
+			// Not connected. Try to connect again.
+			self.connectToFollowerProPresenter();
+		}
+
+	}, 3000);
+
+};
+
+
+/**
+ * Stops the follower reconnection timer.
+ */
+instance.prototype.stopFollowerConnectionTimer = function() {
+	var self = this;
+
+	self.log('debug', "Stopping Follower ConnectionTimer");
+	if (self.reconFollowerTimer !== undefined) {
+		clearInterval(self.reconFollowerTimer);
+		delete self.reconFollowerTimer;
+	}
+
+};
+
 
 /**
  * Updates the connection status variable.
@@ -550,6 +641,7 @@ instance.prototype.setConnectionVariable = function(status, updateLog) {
 	}
 };
 
+
 /**
  * Updates the stage display connection status variable.
  */
@@ -563,6 +655,7 @@ instance.prototype.setSDConnectionVariable = function(status, updateLog) {
 	}
 
 };
+
 
 /**
  * Disconnect the websocket from ProPresenter, if connected.
@@ -596,6 +689,23 @@ instance.prototype.disconnectFromProPresenterSD = function() {
 			self.sdsocket.terminate();
 		}
 		delete self.sdsocket;
+	}
+
+};
+
+
+/**
+ * Disconnect the websocket from Follower ProPresenter, if connected.
+ */
+instance.prototype.disconnectFromFollowerProPresenter = function() {
+	var self = this;
+
+	if (self.followersocket !== undefined) {
+		// Disconnect if already connected
+		if (self.followersocket.readyState !== 3 /*CLOSED*/) {
+			self.followersocket.terminate();
+		}
+		delete self.followersocket;
 	}
 
 };
@@ -645,11 +755,11 @@ instance.prototype.connectToProPresenter = function() {
 
 		self.log('info', 'socket closed');
 
-		self.emptyCurrentState();  // This is also sets self.currentState.internal.wsConnected to false
-
 		if (wasConnected === false) {
 			return;
 		}
+
+		self.emptyCurrentState();  // This is also sets self.currentState.internal.wsConnected to false
 
 		self.status(self.STATUS_ERROR, 'Not connected to ProPresenter');
 		self.setConnectionVariable('Disconnected', true);
@@ -721,11 +831,13 @@ instance.prototype.connectToProPresenterSD = function() {
 		// Reset the current state then abort; don't flood logs with disconnected notices.
 
 		var wasSDConnected = self.currentState.internal.wsSDConnected;
-		self.emptyCurrentState();
 
 		if (wasSDConnected === false) {
 			return;
 		}
+
+		self.emptyCurrentState();
+
 		if  (self.config.use_sd === 'yes') {
 			self.status(self.STATUS_WARNING, 'OK, But Stage Display closed');
 		}
@@ -740,6 +852,72 @@ instance.prototype.connectToProPresenterSD = function() {
 
 };
 
+
+/**
+ * Attempts to open a websocket connection with Follower ProPresenter.
+ */
+instance.prototype.connectToFollowerProPresenter = function() {
+	var self = this;
+
+	// Check for undefined host or port. Also make sure port is [1-65535] and host is least 1 char long.
+	if (!self.config.followerhost || self.config.followerhost.length<1 || !self.config.followerport || self.config.followerport<1 || self.config.followerport>65535) {
+		// Do not try to connect with invalid host or port
+		return;
+	}
+	
+	// Disconnect if already connected
+	self.disconnectFromFollowerProPresenter();
+
+	// Connect to remote control websocket of ProPresenter
+	self.followersocket = new WebSocket('ws://'+self.config.followerhost+':'+self.config.followerport+'/remote');
+
+	self.followersocket.on('open', function open() {
+		self.log('info', "Opened websocket to Follower ProPresenter remote control: " + self.config.followerhost +":"+ self.config.followerport);
+		self.followersocket.send(JSON.stringify({
+			password: self.config.followerpass,
+			protocol: "700", // This will connect to Pro6 and Pro7 (the version check is happy with higher versions)
+			action: "authenticate"
+		}));
+
+	});
+
+	self.followersocket.on('error', function (err) {
+		if (self.config.control_follower === 'yes') {
+			self.status(self.STATUS_WARNING, err.message);
+		}
+	});
+
+	//self.socket.on('connect', function () {
+	//	debug("Connected to ProPresenter remote control");
+	//});
+
+	self.followersocket.on('close', function(code, reason) {
+		// Event is also triggered when a reconnect attempt fails.
+		// Reset the current state then abort; don't flood logs with disconnected notices.
+		var wasFollowerConnected = self.currentState.internal.wsFollowerConnected;
+
+
+		self.log('info', 'Follower ProPresenter socket connection closed');
+
+		self.currentState.internal.wsFollowerConnected = false;
+
+		if (wasFollowerConnected === false) {
+			return;
+		}
+
+		if (self.config.control_follower === 'yes') {
+			self.status(self.STATUS_WARNING, 'Not connected to Follower ProPresenter');
+		}
+		self.setConnectionVariable('Disconnected', true);
+
+	});
+
+	self.followersocket.on('message', function(message) {
+		// Handle the message received from ProPresenter
+		self.onFollowerWebSocketMessage(message);
+	});
+
+};
 
 /**
  * Register the available actions with Companion.
@@ -1005,6 +1183,7 @@ instance.prototype.actions = function(system) {
 	});
 };
 
+
 /**
  * Action triggered by Companion.
  */
@@ -1268,6 +1447,7 @@ instance.prototype.action = function(action) {
 
 };
 
+
 instance.prototype.init_feedbacks = function() {
 	var self = this;
 
@@ -1366,6 +1546,7 @@ instance.prototype.init_feedbacks = function() {
 	self.setFeedbackDefinitions(feedbacks);
 }
 
+
 instance.prototype.feedback = function(feedback, bank) {
 	var self = this;
 
@@ -1403,6 +1584,8 @@ instance.prototype.feedback = function(feedback, bank) {
 	}
 
 }
+
+
 /**
  * Received a message from ProPresenter.
  */
@@ -1433,7 +1616,7 @@ instance.prototype.onWebSocketMessage = function(message) {
 					// Leave default 
 				}
 				
-				self.log('info', 'Authenticated to ProPresenter Version: ' + self.currentState.internal.proMajorVersion);
+				self.log('info', 'Authenticated to ProPresenter (Version: ' + self.currentState.internal.proMajorVersion + ')');
 				self.status(self.STATE_OK);
 				self.currentState.internal.wsConnected = true;
 				// Successfully authenticated. Request current state.
@@ -1449,7 +1632,7 @@ instance.prototype.onWebSocketMessage = function(message) {
 			} else {
 				self.status(self.STATUS_ERROR);
 				// Bad password
-				self.log('warn', objData.error);
+				self.log('warn', 'Failed to authenticate to ProPresenter. ' + objData.error);
 				self.disconnectFromProPresenter();
 
 				// No point in trying to connect again. The user must either re-enable this
@@ -1477,8 +1660,100 @@ instance.prototype.onWebSocketMessage = function(message) {
 			setTimeout(function(){
 				self.getProPresenterState();
 			}, 800);
-			self.log('info', 'presentationSlideIndex: ' + slideIndex);
+			self.log('debug', 'presentationSlideIndex: ' + slideIndex);
+
+			// Trigger same slide in follower ProPresenter (If configured and connected)
+			if (self.config.control_follower === 'yes' && self.currentState.internal.wsFollowerConnected) {
+				cmd = {
+					action: "presentationTriggerIndex",
+					slideIndex: String(slideIndex),
+					// Pro 6 for Windows requires 'presentationPath' to be set.
+					presentationPath: objData.presentationPath
+				};
+				self.log('debug', 'Forwarding command to Follower: ' + JSON.stringify(cmd));
+				try {
+					var cmdJSON = JSON.stringify(cmd);
+					self.followersocket.send(cmdJSON);
+				}
+				catch (e) {
+					debug("Follower NETWORK " + e)
+					self.status(self.STATUS_WARNING, e);
+				}
+			}
+
 			break;
+
+		case 'clearText':
+			// Forward command to follower (TODO: only if clearText is recieved twice quickly)
+			if (self.config.control_follower === 'yes' && self.currentState.internal.wsFollowerConnected) {
+				cmd = {
+					action: "clearText",
+				};
+				self.log('debug', 'Forwarding command to Follower: ' + JSON.stringify(cmd));
+				try {
+					var cmdJSON = JSON.stringify(cmd);
+					self.followersocket.send(cmdJSON);
+				}
+				catch (e) {
+					debug("Follower NETWORK " + e)
+					self.status(self.STATUS_WARNING, e);
+				}
+			}
+			break;
+
+		case 'clearAll':
+			// Forward command to follower
+			if (self.config.control_follower === 'yes' && self.currentState.internal.wsFollowerConnected) {
+				cmd = {
+					action: "clearAll",
+				};
+				self.log('debug', 'Forwarding command to Follower: ' + JSON.stringify(cmd));
+				try {
+					var cmdJSON = JSON.stringify(cmd);
+					self.followersocket.send(cmdJSON);
+				}
+				catch (e) {
+					debug("Follower NETWORK " + e)
+					self.status(self.STATUS_WARNING, e);
+				}
+			}
+			break;
+
+		case 'clearVideo':
+			// Forward command to follower
+			if (self.config.control_follower === 'yes' && self.currentState.internal.wsFollowerConnected) {
+				cmd = {
+					action: "clearVideo",
+				};
+				self.log('debug', 'Forwarding command to Follower: ' + JSON.stringify(cmd));
+				try {
+					var cmdJSON = JSON.stringify(cmd);
+					self.followersocket.send(cmdJSON);
+				}
+				catch (e) {
+					debug("Follower NETWORK " + e)
+					self.status(self.STATUS_WARNING, e);
+				}
+			}
+			break;
+
+		case 'clearAudio':
+			// Forward command to follower
+			if (self.config.control_follower === 'yes' && self.currentState.internal.wsFollowerConnected) {
+				cmd = {
+					action: "clearAudio",
+				};
+				self.log('debug', 'Forwarding command to Follower: ' + JSON.stringify(cmd));
+				try {
+					var cmdJSON = JSON.stringify(cmd);
+					self.followersocket.send(cmdJSON);
+				}
+				catch (e) {
+					debug("Follower NETWORK " + e)
+					self.status(self.STATUS_WARNING, e);
+				}
+			}
+			break;	
 
 		case 'presentationCurrent':
 			var objPresentation = objData.presentation;
@@ -1568,7 +1843,7 @@ instance.prototype.onWebSocketMessage = function(message) {
 							self.currentState.dynamicVariables[stageScreenName + '_pro7_stagelayoutname'] = self.currentState.internal.pro7StageLayouts.find(pro7StageLayout => pro7StageLayout.id === stageLayoutSelectedLayoutUUID).label;
 							self.updateVariable(stageScreenName + '_pro7_stagelayoutname', self.currentState.dynamicVariables[stageScreenName + '_pro7_stagelayoutname']);
 						} catch (e) {
-							self.log('warn', "Error finding/updating layout name for " + stageScreenName + '_pro7_stagelayoutname' ); 
+							self.log('warn', "Error finding/updating layout name for " + stageScreenName + '_pro7_stagelayoutname. ' + e.message); 
 						}
 
 						// Capture the UUID of the current_pro7_stage_layout_name for selected watched screen
@@ -1608,6 +1883,78 @@ instance.prototype.onWebSocketMessage = function(message) {
 
 
 /**
+ * Received a message from Follower ProPresenter.
+ */
+instance.prototype.onFollowerWebSocketMessage = function(message) {
+	var self = this;
+	var objData;
+	// Try to parse websocket payload as JSON...
+	try {
+		objData = JSON.parse(message);
+	} catch (err) {
+		self.log('warn', err.message);
+		return;
+	}
+	
+
+	switch(objData.action) {
+		case 'authenticate':
+			if (objData.authenticated === 1) {
+				
+				// Autodetect if Major version of ProPresenter is version 7
+				// Only Pro7 includes .majorVersion and .minorVersion properties.
+				// .majorVersion will be set to = "7" from Pro7 (Pro6 does not include these at all)
+				if (objData.hasOwnProperty('majorVersion')) {
+					self.log('info', 'Authenticated to Follower ProPresenter (Version: ' + objData.majorVersion + ')');
+				}
+				
+				self.currentState.internal.wsFollowerConnected = true;
+				
+				// TODO: check if this is needed here...
+				// self.init_feedbacks();
+			} else {
+				self.status(self.STATUS_WARNING);
+				self.log('warn', 'Failed to authenticate to Follower ProPresenter'  + objData.error);
+				self.disconnectFromFollowerProPresenter();
+
+				// No point in trying to connect again. The user must either re-enable this
+				//	module or re-save the config changes to make another attempt.
+				self.stopFollowerConnectionTimer();
+
+			}
+			break;
+
+
+		case 'presentationTriggerIndex':
+		case 'presentationSlideIndex':
+			// Update the current slide index.
+			var slideIndex = parseInt(objData.slideIndex, 10);
+			self.log('debug', 'Follower presentationSlideIndex: ' + slideIndex);
+			break;
+
+		case 'presentationCurrent':
+			var objPresentation = objData.presentation;
+
+			// Pro6 PC's 'presentationName' contains the raw file extension '.pro6'. Remove it.
+			var presentationName = objPresentation.presentationName.replace(/\.pro6$/i, '');
+			self.log('info', 'Follower presentationCurrent: ' + presentationName);
+			break;
+
+		case 'clockCurrentTimes':
+			break;
+
+		case 'stageDisplaySetIndex': 
+			break;
+
+		case 'stageDisplaySets':
+			break;
+
+	}
+
+};
+
+
+/**
  * Received a stage display message from ProPresenter.
  */
 instance.prototype.onSDWebSocketMessage = function(message) {
@@ -1641,6 +1988,7 @@ instance.prototype.onSDWebSocketMessage = function(message) {
 
 };
 
+
 /**
  * Requests the current state from ProPresenter.
  */
@@ -1666,6 +2014,7 @@ instance.prototype.getProPresenterState = function() {
 
 };
 
+
 /*
 * Requests the list of configured stage displays (includes names)
 */
@@ -1680,6 +2029,7 @@ instance.prototype.getStageDisplaysInfo = function() {
 		action: 'stageDisplaySets'
 	}));
 }
+
 
 instance_skel.extendedBy(instance);
 exports = module.exports = instance;


### PR DESCRIPTION
Added "Leader-Follower" Beta Feature - to emulate the old Pro6 Master-Control module.
You can optionally configure a Follower Pro7 machine that this module will automatically control by sending slide trigger and clear actions to match what is happening on the main Pro7 machine (Leader).
This is an early beta feature - which may not be needed for long if RV make a better built-in feature to do the same.