### PR TITLE
New Actions: Set Look, Trigger Macro!

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -84,6 +84,16 @@ Example Playlist:
   * Presentation B (index=3)
   * Presentation C (index=4)
 
+## Pro7 Looks
+Command | Description
+------- | -----------
+Pro7&nbsp;Set&nbsp;Look | Choose a Look to set live in Pro7
+
+## Pro7 Macros
+Command | Description
+------- | -----------
+Pro7&nbsp;Trigger&nbsp;Macro | Choose a Macro to trigger in Pro7
+
 ## Audio Cues
 Command | Description
 ------- | -----------
@@ -166,3 +176,4 @@ $(propresenter:current_stage_display_name) | Name of the currently selected stag
 $(propresenter:video_countdown_timer) | Current value of video countdown timer - automatically updated when a video is playing. (This one variable is only updated when the module is configured to also connect to the Stage Display App port)
 $(propresenter:current_pro7_stage_layout_name) | The name of the current stage-display layout on the selected stage-display screen (as set in module config)
 $(propresenter:*StageScreenName*_pro7_stagelayoutname) | The name of the current stage-display layout on the stage screen with name: "stageScreenName" (Case Sensitive)
+$(propresenter2:current_pro7_look_name) | The name of the current Pro7 Look that is live (not yet working)

--- a/index.js
+++ b/index.js
@@ -430,6 +430,7 @@ instance.prototype.emptyCurrentState = function() {
 		current_stage_display_name: 'N/A',
 		current_stage_display_index: 'N/A',
 		current_pro7_stage_layout_name: "N/A",
+		current_pro7_look_name: "N/A",
 	};
 
 	// Update Companion with the default state if each dynamic variable.
@@ -477,6 +478,10 @@ instance.prototype.initVariables = function() {
 		{
 			label: 'Current Pro7 Stage Layout Name',
 			name:  'current_pro7_stage_layout_name'
+		},
+		{
+			label: 'Current Pro7 Look Name',
+			name: 'current_pro7_look_name'
 		},
 		{
 			label: 'Current Stage Display Name',
@@ -1011,7 +1016,7 @@ instance.prototype.actions = function(system) {
 			]
 		},
 		'pro7TriggerMacro': {
-			label: 'pro7 Trigger Macro',
+			label: 'Pro7 Trigger Macro',
 			options: [
 				{
 					type: 'dropdown',
@@ -2030,7 +2035,10 @@ instance.prototype.onWebSocketMessage = function(message) {
 					var lookID = look['lookID'];
 					self.currentState.internal.pro7Looks.push({id: lookID, label: lookName});
 				});
+				// Update dyn var for current look name
+				self.updateVariable('current_pro7_look_name', objData.activeLook.lookName);
 
+				self.log('info', objData.activeLook.lookName);
 				self.log('info', "Got Pro7 Looks List");
 				self.actions(); // Update dropdown lists for Looks
 			}

--- a/index.js
+++ b/index.js
@@ -412,6 +412,8 @@ instance.prototype.emptyCurrentState = function() {
 		pro7StageLayouts: [{ id: '0', label: 'Connect to Pro7 to Update' }],
 		pro7StageScreens: [{ id: '0', label: 'Connect to Pro7 to Update' }],
 		previousTimeOfLeaderClearMessage: null,
+		pro7Looks: [{id: '0', label: 'Connect to Pro7 to Update' }],
+		pro7Macros: [{id: '0', label: 'Connect to Pro7 to Update' }],
 	};
 
 	// The dynamic variable exposed to Companion
@@ -995,6 +997,32 @@ instance.prototype.actions = function(system) {
 				}
 			]
 		},
+		'pro7SetLook': {
+			label: 'Pro7 Set Look',
+			options: [
+				{
+					type: 'dropdown',
+					label: 'Look',
+					id: 'pro7LookUUID',
+					tooltip: 'Choose which Look to make live',
+					default: '',
+					choices: self.currentState.internal.pro7Looks
+				}
+			]
+		},
+		'pro7TriggerMacro': {
+			label: 'pro7 Trigger Macro',
+			options: [
+				{
+					type: 'dropdown',
+					label: 'Macro',
+					id: 'pro7MacroUUID',
+					tooltip: 'Choose which Macro to trigger',
+					default: '',
+					choices: self.currentState.internal.pro7Macros
+				}
+			]
+		},
 		'stageDisplayMessage': {
 			label: 'Stage Display Message',
 			options: [
@@ -1348,6 +1376,22 @@ instance.prototype.action = function(action) {
 				stageLayoutUUID: opt.pro7StageLayoutUUID ? opt.pro7StageLayoutUUID : self.currentState.internal.pro7StageLayouts[0].id,
 			};
 			break;
+
+		case 'pro7SetLook':
+			// If selected Look is null, then default to using first Look from list kept in internal state
+			cmd = {
+				action: "looksTrigger",
+				lookID: opt.pro7LookUUID ? opt.pro7LookUUID : self.currentState.internal.pro7Looks[0].id
+			}
+			break;
+
+		case 'pro7TriggerMacro':
+			// If selected Macro is null, then default to using first Macro from list kept in internal state
+			cmd = {
+				action: "macrosTrigger",
+				macroID: opt.pro7MacroUUID ? opt.pro7MacroUUID : self.currentState.internal.pro7Macros[0].id
+			}
+			break;	
 
 		case 'stageDisplayMessage':
 			//var message = JSON.stringify(opt.message);
@@ -1723,6 +1767,12 @@ instance.prototype.onWebSocketMessage = function(message) {
 				self.init_feedbacks();
 				// Get current Stage Display (index and Name)
 				self.getStageDisplaysInfo();
+				// Get current Pro7 Macros & Looks List.
+				if (self.currentState.internal.proMajorVersion >= 7) {
+					self.getMacrosList();
+					self.getLooksList();
+				}
+					
 				// Ask Pro6 to start sending clock updates (they are sent once per second)
 				self.socket.send(JSON.stringify({
 					action: 'clockStartSendingCurrentTime'
@@ -1971,6 +2021,33 @@ instance.prototype.onWebSocketMessage = function(message) {
 				self.init_feedbacks(); // Update dropdown lists for pro7 stage layout feedback.
 			}
 			break;
+		
+		case 'looksRequest':  // Response from sending looksRequest
+			if (objData.hasOwnProperty('looks')) {
+				self.currentState.internal.pro7Looks = [];
+				objData.looks.forEach(function(look) {
+					var lookName = look['lookName'];
+					var lookID = look['lookID'];
+					self.currentState.internal.pro7Looks.push({id: lookID, label: lookName});
+				});
+
+				self.log('info', "Got Pro7 Looks List");
+				self.actions(); // Update dropdown lists for Looks
+			}
+			break;
+		
+		case 'macrosRequest':  // Response from sending macrosRequest
+			if (objData.hasOwnProperty('macros')) {
+				self.currentState.internal.pro7Macros = [];
+				objData.macros.forEach(function(look) {
+					var macroName = look['macroName'];
+					var macroID = look['macroID'];
+					self.currentState.internal.pro7Macros.push({id: macroID, label: macroName});
+				});
+
+				self.log('info', "Got Pro7 Macros List");
+				self.actions(); // Update dropdown lists for Looks
+			}
 
 	}
 
@@ -2128,6 +2205,36 @@ instance.prototype.getStageDisplaysInfo = function() {
 
 	self.socket.send(JSON.stringify({
 		action: 'stageDisplaySets'
+	}));
+}
+
+/*
+* Request Looks List
+*/
+instance.prototype.getLooksList = function () {
+	var self = this;
+
+	if (self.currentState.internal.wsConnected === false) {
+		return;
+	}
+
+	self.socket.send(JSON.stringify({
+		action: 'looksRequest'
+	}));
+}
+
+/*
+* Request Macros List
+*/
+instance.prototype.getMacrosList = function () {
+	var self = this;
+
+	if (self.currentState.internal.wsConnected === false) {
+		return;
+	}
+
+	self.socket.send(JSON.stringify({
+		action: 'macrosRequest'
 	}));
 }
 


### PR DESCRIPTION
Latest version of Pro7 supports triggering macros and setting looks via the remote protocol.
(There is no feedbac when the active look changes yet - Will update feedback when this is added to Pro7)