### PR TITLE
Add dynamic vars for all timers/clocks

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -176,4 +176,5 @@ $(propresenter:current_stage_display_name) | Name of the currently selected stag
 $(propresenter:video_countdown_timer) | Current value of video countdown timer - automatically updated when a video is playing. (This one variable is only updated when the module is configured to also connect to the Stage Display App port)
 $(propresenter:current_pro7_stage_layout_name) | The name of the current stage-display layout on the selected stage-display screen (as set in module config)
 $(propresenter:*StageScreenName*_pro7_stagelayoutname) | The name of the current stage-display layout on the stage screen with name: "stageScreenName" (Case Sensitive)
-$(propresenter2:current_pro7_look_name) | The name of the current Pro7 Look that is live (not yet working)
+$(propresenter:pro7_clock_n) | hh:mm:ss for clock with index n
+$(propresenter:pro7_clock_n_hourless) | mm:ss for clock with index n

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 		"propresenter6",
 		"propresenter"
 	],
-	"version": "2.4.0",
+	"version": "2.4.1",
 	"api_version": "1.0.0",
 	"keywords": [
 		"Software",


### PR DESCRIPTION
 This version dynamically adds vars for all timers/clocks.

```
$(propresenter:pro7_clock_n) = hh:mm:ss for clock with index n
$(propresenter:pro7_clock_n_hourless) = mm:ss for clock with index n
```

 Still keeping old single var `$(propresenter:watched_clock_current_time)` for backwards compatibility in users setups)
