### PR TITLE
New BETA actions. Better variables support

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -1,12 +1,13 @@
 # Companion-module: ProPresenter6/7
 
 
-Module for using ProPresenter 6 or 7 with the Elgato Stream Deck and Companion. Requires a network connection to ProPresenter via it's Remote network port.
+Module for remotely controlling ProPresenter 6 or 7 with the Elgato Stream Deck and Companion. Requires a network connection to ProPresenter via it's Remote network port.
 
 *Optionally, you can also configure a connection to the Stage Display App port if you want to track the Video CountDown Timer for any video that is playing.*
 
 # Setup Guide.
 ## Enable networking in ProPresenter if you haven't already done so...
+## Also enable Network Link to use new beta actions
 1. Open ProPresenter and then open the "ProPresenter (6)" Menu.
 2. Select "Preferences..." to open the ProPresenter Preferences window.
 3. Select the Network tab to configure ProPresenter network preferences.
@@ -18,14 +19,14 @@ Module for using ProPresenter 6 or 7 with the Elgato Stream Deck and Companion. 
 9. If you would like your StreamDeck to be able to display "Video CountDown" timers, then you will also need to check the option for "Enable Stage Display App" and enter a new password (or take note of the existing password).
 9. Close ProPresenter preferences window.
 
-## Get the IP address of the computer running ProPresenter
-You can control ProPresenter on any computer within the same network, you just need to know the ProPresenter computer IP address. Use your knowledge of networking (or Google how) to get the IP address of the *computer running ProPresenter*.
+## Get the IP address (or hostname) of the computer running ProPresenter
+You can control ProPresenter on any computer within the same network, you just need to know the ProPresenter computer IP address (or hostname). Use your knowledge of networking (or Google how) to get the IP address (or hostname) of the *computer running ProPresenter*.
 
 ### Networking Tips:
 
-If you want to connect to ProPresenter on the *same* computer that you are running Companion on, you can use the special looback IP address of 127.0.0.1 (which is the default setting)
+If you want to connect to ProPresenter on the *same* computer that you are running Companion on, you can use the special loopback IP address of 127.0.0.1 (which is the default setting)
 
-If the computers running ProPresenter and Companion are separate computers and they have the option of using either a wireless or a wired network connection, then it is recommended to use a wired network connection whenever possible. This is because a wired network connection is *typically* more reliable and has better latency - which is good for remote control.
+If the computers running ProPresenter and Companion are separate computers and they have the option of using either a wireless or a wired network connection, then it is recommended to use a wired network connection whenever possible. This is because a wired network connection is *typically* more reliable and has better latency - which is nice for remote control.
 
 ## Configure the ProPresenter module in Companion
 Now you have all the info you need to go to the ProPresenter Companion module configuration and enter the IP address of the computer running ProPresenter as well as the ProPresenter port number and controller password that you took note of from ProPresenter network preferences.
@@ -34,11 +35,10 @@ If you chose to also enable the stage display app option in ProPresenter prefere
 
 N.B. At the time of writing this module, there is a bug in ProPresenter 6 where if you choose to enter a Port number for the stage display app - it will actually ignore it and use the "main" network port you recorded in step 8 above.
 
-Pro7 users:  Currently there is a noticeable performance impact within ProPresenter 7 itself when companion sends messages to Pro7 to track info about the current presentation.
-To work around this, there is now a new option called "Send Presentation Info Requests To ProPresenter" in the module configuration where you can optionally turn that off.  Doing so will remove the performance impact (random lag when changing slides) but will stop updating the dynamic variables: remaining_slides, total_slides or presentation_name.  You will no longer be able to display them on buttons. We will continue to investigate a fix with RenewedVision (or a better workaround).
+**Pro7 users:  Currently there is a noticeable performance impact within ProPresenter 7 itself when companion sends messages to Pro7 to track info about the current presentation.** To work around this, there is now a new option called "Send Presentation Info Requests To ProPresenter" in the module configuration where you can optionally turn that off.  Doing so will remove the performance impact (random lag when changing slides) but will stop updating the dynamic variables: remaining_slides, total_slides or presentation_name.  You will no longer be able to display them on buttons. We will continue to investigate a fix with RenewedVision (or a better workaround).
 
 ## Optional (Beta) Leader-Follower Feature
-You can optionally configure a second connection to a "Follower" ProPresenter 7 computer to have the module automatically forward slide trigger and clears actions to the Follower as you click on slides (or use clear actions) on the main ProPresenter computer (The Leader).  This emulates the old Pro6 Master-Control module.  It's not complete as some actions cannot be captured by the module to forward to the Follower (the remote protocol does not send notifications for every action - but as it improves, this module will be updated).  For now basic slide triggers and some clear actions do work - This might be enough for some people (until RV introduce a new feature in Pro7 to do the same).
+You can optionally configure a second connection to a "Follower" ProPresenter 7 computer to have the module automatically forward slide trigger and clears actions to the Follower as you click on slides (or use clear actions) on the main ProPresenter computer (The Leader).  This emulates the old Pro6 Master-Control module.  It's not complete as some actions cannot be captured by the module to forward to the Follower (the remote protocol does not send notifications for every action - but as it improves, this module will be updated).  For now basic slide triggers and some clear actions do work. - This won't really be updated any further as there is now a much better "Network Link" feature in Pro7.8+
 
 # Commands
 ## Slides
@@ -59,7 +59,6 @@ A slide number of `0` will trigger the current slide, which can be used to bring
 
 A relative number (prefixed with `+` or `-`) will move the presentation +/- that many slides. `+3` will jump ahead three slides, and `-2` will jump back two slides. Try to avoid using `-1` or `+1` relative numbers; use the `Next Slide` and `Previous Slide` actions instead, as they perform better.
 
-
 **Presentation Path**: Lets you trigger a slide in a different presentation, even from a different playlist.
 
 *Important: Presentation path numbering starts at 0, meaning `0` will trigger a slide in the first presentation in the playlist.*
@@ -67,6 +66,8 @@ A relative number (prefixed with `+` or `-`) will move the presentation +/- that
 A single number, like `3`, will let you trigger a slide in the *fourth* presentation in the **current playlist**.
 
 A path like `1:3` will trigger presentation #4 in playlist #2.
+
+Note that you can use Companion custom or module variables in the Slide Number and Presentation Path fields.
 
 Playlists in groups (or nested groups) are identified using periods. `1.1.0:2` means "The second playlist is a group. The second item in that group is another group. Select the first playlist in that group. Choose the third presentation in the playlist."
 
@@ -178,3 +179,19 @@ $(propresenter:current_pro7_stage_layout_name) | The name of the current stage-d
 $(propresenter:*StageScreenName*_pro7_stagelayoutname) | The name of the current stage-display layout on the stage screen with name: "stageScreenName" (Case Sensitive)
 $(propresenter:pro7_clock_n) | hh:mm:ss for clock with index n
 $(propresenter:pro7_clock_n_hourless) | mm:ss for clock with index n
+
+## ⚠️⚠️⚠️ New BETA actions using Network Link ⚠️⚠️⚠️
+Turning on the Network Link feature in the Network Preferences of ProPresenter 7.8+ enabls a new API that is not yet public (but is planned to be released earl 2022).  Once released, a new Companion module will be made using that instead of the reversed engineered remote protocol.
+Until then, you can _optionally_ decide to try out some of the new actions through this new API.  Please note that since the API is not yet public/final - it may undergo breaking changes until then. They are unlikely to cause any issue - they just may stop working with a future Pro7 update (until this module is updated again). Many of these actions were not possible using the old remote API. (including specifying names instead of indexes!)
+
+Command | Description
+------- | -----------
+Specific Slide (Network Link - Beta) | Trigger a specific slide by Playlist name, Presentation name and Slide index.
+Prop Trigger (Network Link - Beta)  | Trigger a specifc Prop using (by name)
+Prop Clear (Network Link - Beta) | Clear a specific Prop using (by name)
+Message Clear (Network Link - Beta) | Clear a specific Message (by name)
+Trigger Media (Network Link - Beta) | Trigger a specific Media Item by Playlist name and Media name.
+Trigger Audio (Network Link - Beta) | Trigger a specific Audio Item by Playlist name and Audio name.
+Trigger Video Input (Network Link - Beta) | Trigger a specific Video Input by name
+Custom Action (Network Link - Beta) | Send custom JSON to custom endpoint (Advanced use only)
+

--- a/index.js
+++ b/index.js
@@ -20,10 +20,12 @@ function instance(system, id, config) {
  *
  * .internal contains the internal state of the module
  * .dynamicVariable contains the values of the dynamic variables
+ * .dynamicVariablesDefs contains the definitions of the dynamic variables - this list is passed to self.setVariableDefinitions() so  WebUI etc can know what the module vars are.
  */
 instance.prototype.currentState = {
 	internal: {},
 	dynamicVariables: {},
+	dynamicVariablesDefs: [],
 }
 
 /**
@@ -430,6 +432,7 @@ instance.prototype.emptyCurrentState = function () {
 	// The dynamic variable exposed to Companion
 	self.currentState.dynamicVariables = {
 		current_slide: 'N/A',
+		current_presentation_path: 'N/A',
 		remaining_slides: 'N/A',
 		total_slides: 'N/A',
 		presentation_name: 'N/A',
@@ -444,22 +447,14 @@ instance.prototype.emptyCurrentState = function () {
 		current_pro7_look_name: 'N/A',
 	}
 
-	// Update Companion with the default state if each dynamic variable.
-	Object.keys(self.currentState.dynamicVariables).forEach(function (key) {
-		self.updateVariable(key, self.currentState.dynamicVariables[key])
-	})
-}
-
-/**
- * Initialize the available variables. (These are listed in the module config UI)
- */
-instance.prototype.initVariables = function () {
-	var self = this
-
-	var variables = [
+	self.currentState.dynamicVariablesDefs = [
 		{
 			label: 'Current slide number',
 			name: 'current_slide',
+		},
+		{
+			label: 'Current Presentation Path',
+			name: 'current_presentation_path'
 		},
 		{
 			label: 'Remaining Slides',
@@ -507,10 +502,21 @@ instance.prototype.initVariables = function () {
 		},
 	]
 
-	self.setVariableDefinitions(variables)
+	// Update Companion with the default state if each dynamic variable.
+	Object.keys(self.currentState.dynamicVariables).forEach(function (key) {
+		self.updateVariable(key, self.currentState.dynamicVariables[key])
+	})
+}
+
+/**
+ * Initialize the available variables. (These are listed in the module config UI)
+ */
+instance.prototype.initVariables = function () {
+	var self = this
 
 	// Initialize the current state and update Companion with the variables.
 	self.emptyCurrentState()
+	self.setVariableDefinitions(self.currentState.dynamicVariablesDefs)  // Make sure to call this after self.emptyCurrentState() as it intializes self.currentState.dynamicVariablesDefs 
 }
 
 /**
@@ -619,11 +625,15 @@ instance.prototype.startFollowerConnectionTimer = function () {
 	self.log('debug', 'Starting Follower ConnectionTimer')
 	// Create a reconnect timer to watch the socket. If disconnected try to connect.
 	self.reconFollowerTimer = setInterval(function () {
-		if (self.followersocket === undefined || self.followersocket.readyState === 3 /*CLOSED*/) {
-			// Not connected. Try to connect again.
+		if (self.followersocket === undefined || self.followersocket.readyState === 3 /*CLOSED*/ || self.followersocket.readyState === 2 /*CLOSING*/) {
+			// Not connected. 
+			self.currentState.internal.wsFollowerConnected = false
+			// Try to connect again.
 			self.connectToFollowerProPresenter()
 		} else {
-			self.currentState.internal.wsFollowerConnected = true
+			if (self.followersocket.readyState === 1 /*OPEN*/) {
+				self.currentState.internal.wsFollowerConnected = true
+			}
 		}
 	}, 3000)
 }
@@ -910,6 +920,7 @@ instance.prototype.connectToFollowerProPresenter = function () {
 		if (self.config.control_follower === 'yes') {
 			self.log('warn', 'Follower Socket error: ' + err.message)
 		}
+		self.currentState.internal.wsFollowerConnected = false
 	})
 
 	self.followersocket.on('close', function (code, reason) {
@@ -943,14 +954,14 @@ instance.prototype.actions = function (system) {
 			label: 'Specific Slide',
 			options: [
 				{
-					type: 'textinput',
+					type: 'textwithvariables',
 					label: 'Slide Number',
 					id: 'slide',
 					default: 1,
 					regex: self.REGEX_SIGNED_NUMBER,
 				},
 				{
-					type: 'textinput',
+					type: 'textwithvariables',
 					label: 'Presentation Path',
 					id: 'path',
 					default: '',
@@ -1253,9 +1264,9 @@ instance.prototype.actions = function (system) {
 			options: [
 				{
 					type: 'textinput',
-					label: 'Play List Name',
+					label: 'Playlist Name',
 					id: 'playlistName',
-					tooltip: 'Name of the playlist that contains the presentation with the slide you want to trigger',
+					tooltip: 'Name of the PlayList that contains the presentation with the slide you want to trigger',
 				},
 				{
 					type: 'textinput',
@@ -1267,8 +1278,103 @@ instance.prototype.actions = function (system) {
 					type: 'textinput',
 					label: 'Slide Index',
 					id: 'slideIndex',
-					tooltip: 'Index of the slide you want to trigger',
+					tooltip: 'Index of the slide you want to trigger (1-based)',
 					regex: self.REGEX_NUMBER,
+				},
+			],
+		},
+		nwPropTrigger: {
+			label: 'Prop Trigger (Network Link - Beta)',
+			options: [
+				{
+					type: 'textinput',
+					label: 'Prop Name',
+					id: 'propName',
+					tooltip: 'Name of the Prop you want to trigger',
+				},
+			],
+		},
+		nwPropClear: {
+			label: 'Prop Clear (Network Link - Beta)',
+			options: [
+				{
+					type: 'textinput',
+					label: 'Message Name',
+					id: 'messageName',
+					tooltip: 'Name of the Message you want to clear',
+				},
+			],
+		},
+		nwMessageClear: {
+			label: 'Message Clear (Network Link - Beta)',
+			options: [
+				{
+					type: 'textinput',
+					label: 'Prop Name',
+					id: 'propName',
+					tooltip: 'Name of the Prop you want to clear',
+				},
+			],
+		},
+		nwTriggerMedia: {
+			label: 'Trigger Media (Network Link - Beta)',
+			options: [
+				{
+					type: 'textinput',
+					label: 'Media Playlist Name',
+					id: 'playlistName',
+					tooltip: 'Name of the Media PlayList that contains the media file you want to trigger',
+				},
+				{
+					type: 'textinput',
+					label: 'Media Name',
+					id: 'mediaName',
+					tooltip: 'Name of the media file you want to trigger',
+				},
+			],
+		},
+		nwTriggerAudio: {
+			label: 'Trigger Audio (Network Link - Beta)',
+			options: [
+				{
+					type: 'textinput',
+					label: 'Audio Playlist Name',
+					id: 'playlistName',
+					tooltip: 'Name of the Audio PlayList that contains the audio file you want to trigger',
+				},
+				{
+					type: 'textinput',
+					label: 'Audio Name',
+					id: 'audioName',
+					tooltip: 'Name of the audio file you want to trigger',
+				},
+			],
+		},
+		nwVideoInput: {
+			label: 'Trigger Video Input (Network Link - Beta)',
+			options: [
+				{
+					type: 'textinput',
+					label: 'Video Input Name',
+					id: 'videoInputName',
+					tooltip: 'Name of the video input you want to trigger',
+				},
+			],
+		},
+		nwCustom: {
+			label: 'Custom Action (Network Link - Beta)',
+			options: [
+				{
+					type: 'textinput',
+					label: 'Endpoint Path',
+					id: 'endpointPath',
+					tooltip: 'REST Endpoint path (must start with /)',
+				},
+				{
+					type: 'textinput',
+					label: 'JSON Data',
+					id: 'jsonData',
+					tooltip: 'JSON Data (no single quotes, no trailing commas)',
 				},
 			],
 		},
@@ -1315,7 +1421,13 @@ instance.prototype.action = function (action) {
 			break
 
 		case 'slideNumber':
-			var index = self.currentState.internal.slideIndex
+			var index = self.currentState.internal.slideIndex // Start with current slide (allows relative jumps using+-)
+
+			// Allow parsing of optional variable in the slide textfield as int
+			var optSlideIndex
+			self.system.emit('variable_parse', action.options.slide.trim(), function (value) { // Picking a var from the dropdown seems to add a space on end (use trim() to ensure field is a just a clean variable)
+				optSlideIndex = value
+			})
 
 			if (opt.slide[0] === '-' || opt.slide[0] === '+') {
 				// Move back/forward a relative number of slides.
@@ -1323,7 +1435,7 @@ instance.prototype.action = function (action) {
 				index = Math.max(0, index)
 			} else {
 				// Absolute slide number. Convert to an index.
-				index = parseInt(opt.slide) - 1
+				index = parseInt(optSlideIndex) - 1
 			}
 
 			if (index < 0) {
@@ -1334,6 +1446,12 @@ instance.prototype.action = function (action) {
 				index = self.currentState.internal.slideIndex
 			}
 
+			// Allow parsing of optional variable in the presentationPath textfield as string
+			var optPath
+			self.system.emit('variable_parse', action.options.path.trim(), function (value) { // Picking a var from the dropdown seems to add a space on end (use trim() to ensure field is a just a clean variable)
+				optPath = value
+			})
+
 			var presentationPath = self.currentState.internal.presentationPath
 			if (opt.path !== undefined && opt.path.match(/^\d+$/) !== null) {
 				// Is a relative presentation path. Refers to the current playlist, so extract it
@@ -1341,7 +1459,7 @@ instance.prototype.action = function (action) {
 				presentationPath = presentationPath.split(':')[0] + ':' + opt.path
 			} else if (opt.path !== '') {
 				// Use the path provided. The option's regex validated the format.
-				presentationPath = opt.path
+				presentationPath = optPath
 			}
 
 			cmd = {
@@ -1591,6 +1709,81 @@ instance.prototype.action = function (action) {
 				}
 			}
 			break
+		case 'nwPropTrigger':
+			nwCmd = {
+				endpointPath: '/prop/trigger',
+				data: { id:
+					{
+						name: opt.propName
+					}
+				}
+			}
+			break
+		case 'nwPropClear':
+			nwCmd = {
+				endpointPath: '/prop/clear',
+				data: { id:
+					{
+						name: opt.propName
+					}
+				}
+			}
+			break
+		case 'nwMessageClear':
+			nwCmd = {
+				endpointPath: '/message/clear',
+				data: { id:
+					{
+						name: opt.messageName
+					}
+				}
+			}
+			break
+		case 'nwTriggerMedia':
+			nwCmd = {
+				endpointPath: '/trigger/media',
+				data: { path:
+					[
+						{
+							name: opt.playlistName
+						},
+						{
+							name: opt.mediaName
+						}
+					]
+				}
+			}
+			break
+		case 'nwTriggerAudio':
+			nwCmd = {
+				endpointPath: '/trigger/audio',
+				data: { path:
+					[
+						{
+							name: opt.playlistName
+						},
+						{
+							name: opt.audioName
+						}
+					]
+				}
+			}
+			break
+		case 'nwVideoInput':
+			nwCmd = {
+				endpointPath: '/trigger/video_input',
+				data: { id:
+					{
+						name: opt.videoInputName
+					}
+				}
+			}
+			break
+		case 'nwCustom':
+			nwCmd = {
+				endpointPath: opt.endpointPath,
+				data: JSON.parse(opt.jsonData)
+			}
 	}
 
 	// Perform actions that use the current ProRemote API (Websocket)
@@ -1601,7 +1794,7 @@ instance.prototype.action = function (action) {
 				self.socket.send(cmdJSON)
 			} catch (e) {
 				self.log('debug','NETWORK ' + e)
-				self.status(self.STATUS_ERROR, e)
+				self.status(self.STATUS_ERROR, e.message)
 			}
 		} else {
 			self.log('debug','Socket not connected :(')
@@ -1824,6 +2017,7 @@ instance.prototype.feedback = function (feedback, bank) {
 instance.prototype.onWebSocketMessage = function (message) {
 	var self = this
 	var objData
+
 	// Try to parse websocket payload as JSON...
 	try {
 		objData = JSON.parse(message)
@@ -1886,6 +2080,7 @@ instance.prototype.onWebSocketMessage = function (message) {
 
 			self.currentState.internal.slideIndex = slideIndex
 			self.updateVariable('current_slide', slideIndex + 1)
+			self.updateVariable('current_presentation_path', String(objData.presentationPath))
 			if (objData.presentationPath == self.currentState.internal.presentationPath) {
 				// If the triggered slide is part of the current presentation (for which we have stored the total slides) then update the 'remaining_slides' dynamic variable
 				// Note that, if the triggered slide is NOT part of the current presentation, the 'remaining_slides' dynamic variable will be updated later when we call the presentationCurrent action to refresh current presentation info.
@@ -1912,7 +2107,6 @@ instance.prototype.onWebSocketMessage = function (message) {
 					self.followersocket.send(cmdJSON)
 				} catch (e) {
 					self.log('debug','Follower NETWORK ' + e)
-					self.status(self.STATUS_WARNING, e)
 				}
 			}
 
@@ -1936,7 +2130,6 @@ instance.prototype.onWebSocketMessage = function (message) {
 					self.followersocket.send(cmdJSON)
 				} catch (e) {
 					self.log('debug','Follower NETWORK ' + e)
-					self.status(self.STATUS_WARNING, e)
 				}
 			}
 			self.currentState.internal.previousTimeOfLeaderClearMessage = timeOfThisClearMessage
@@ -1954,7 +2147,6 @@ instance.prototype.onWebSocketMessage = function (message) {
 					self.followersocket.send(cmdJSON)
 				} catch (e) {
 					self.log('debug','Follower NETWORK ' + e)
-					self.status(self.STATUS_WARNING, e)
 				}
 			}
 			break
@@ -1971,7 +2163,6 @@ instance.prototype.onWebSocketMessage = function (message) {
 					self.followersocket.send(cmdJSON)
 				} catch (e) {
 					self.log('debug','Follower NETWORK ' + e)
-					self.status(self.STATUS_WARNING, e)
 				}
 			}
 			break
@@ -1988,7 +2179,6 @@ instance.prototype.onWebSocketMessage = function (message) {
 					self.followersocket.send(cmdJSON)
 				} catch (e) {
 					self.log('debug','Follower NETWORK ' + e)
-					self.status(self.STATUS_WARNING, e)
 				}
 			}
 			break
@@ -2033,18 +2223,37 @@ instance.prototype.onWebSocketMessage = function (message) {
 
 		case 'clockCurrentTimes':
 			var objClockTimes = objData.clockTimes
-			
+
 			// Update dyn var for watched clock/timer
 			if (self.config.indexOfClockToWatch >= 0 && self.config.indexOfClockToWatch < objData.clockTimes.length) {
 				self.updateVariable('watched_clock_current_time', objData.clockTimes[self.config.indexOfClockToWatch])
 			}
-			
+		
 			// Update complete list of dyn vars for all clocks/timers (two for each clock - one with and one without hours)
+			var updateModuleVars = false
 			for (let clockIndex = 0; clockIndex < objClockTimes.length; clockIndex++) {
 				self.currentState.dynamicVariables['pro7_clock_' + clockIndex] = self.formatClockTime(objClockTimes[clockIndex])
 				self.updateVariable('pro7_clock_' + clockIndex, self.currentState.dynamicVariables['pro7_clock_' + clockIndex])
+				// If we don't already have this dynamic var defined then add a definition for it (we'll update Companion once loop is done)
+				var varDef = { label: 'Pro7 Clock ' + clockIndex, name: 'pro7_clock_' + clockIndex}
+				if (!self.currentState.dynamicVariablesDefs.some(({name}) => name === varDef.name)) {
+					self.currentState.dynamicVariablesDefs.push(varDef)
+					updateModuleVars = true
+				}
+
 				self.currentState.dynamicVariables['pro7_clock_' + clockIndex + '_hourless'] = self.formatClockTime(objClockTimes[clockIndex], false)
 				self.updateVariable('pro7_clock_' + clockIndex + '_hourless', self.currentState.dynamicVariables['pro7_clock_' + clockIndex + '_hourless'])
+				// If we don't already have this dynamic var defined then add a definition for it (we'll update Companion once loop is done)
+				var varDef = { label: 'Pro7 Clock ' + clockIndex + ' Hourless', name: 'pro7_clock_' + clockIndex + '_hourless'}
+				if (!self.currentState.dynamicVariablesDefs.some(({name}) => name === varDef.name)) {
+					self.currentState.dynamicVariablesDefs.push(varDef)
+					updateModuleVars = true
+				}
+			}
+
+			// Tell Companion about any new module vars for clocks that were added (so they become visible in WebUI etc)
+			if (updateModuleVars) {
+				self.setVariableDefinitions(self.currentState.dynamicVariablesDefs)
 			}
 			
 			break
@@ -2059,9 +2268,11 @@ instance.prototype.onWebSocketMessage = function (message) {
 			}
 			break
 
-		case 'stageDisplaySets': // The response from sending stageDisplaySets is a reply that includes an array of Stage Display Layout Names, and also stageDisplayIndex set to the index of the currently selected layout
+		case 'stageDisplaySets':
 			if (self.currentState.internal.proMajorVersion === 6) {
+				// ******* PRO6 *********
 				// Handle Pro6 Stage Display Info...
+				// The Pro6 response from sending stageDisplaySets is a reply that includes an array of stageDisplaySets, and an index "stageDisplayIndex" that is set to the index of the currently selected layout for the single stage display in Pro6
 				var stageDisplaySets = objData.stageDisplaySets
 				var stageDisplayIndex = objData.stageDisplayIndex
 				self.currentState.internal.stageDisplayIndex = parseInt(stageDisplayIndex, 10)
@@ -2069,12 +2280,19 @@ instance.prototype.onWebSocketMessage = function (message) {
 				self.updateVariable('current_stage_display_name', stageDisplaySets[parseInt(stageDisplayIndex, 10)])
 				self.checkFeedbacks('stagedisplay_active')
 			} else if (self.currentState.internal.proMajorVersion === 7) {
+				// ******* PRO7 *********
 				// Handle Pro7 Stage Display Info...
+				// The Pro7 response from sending stageDisplaySets is a reply that includes TWO arrays/lists
+				// The list "stageLayouts" includes the name and id of each stagelayout defined in Pro7
+				// The list "stageScreens: includes name, id and id of the selected stageLayout for all stage output screens defined in Pro7
 				var watchScreen_StageLayoutSelectedLayoutUUID = ''
 
-				// Refresh list of all stagelayouts
+				// Refresh list of all stageLayouts (name and id)
 				if (objData.hasOwnProperty('stageLayouts')) {
+					// Empty old list of stageLayouts
 					self.currentState.internal.pro7StageLayouts = []
+
+					// Refresh list from new data
 					objData.stageLayouts.forEach(function (stageLayout) {
 						self.currentState.internal.pro7StageLayouts.push({
 							id: stageLayout['stageLayoutUUID'],
@@ -2083,9 +2301,16 @@ instance.prototype.onWebSocketMessage = function (message) {
 					})
 				}
 
-				// Refresh list of stage screens, update the records of screen names (and layout UUID), and record UUID of the current_pro7_stage_layout_name for selected watched screen
+				// Refresh list of stage OUTPUT SCREENS
+				// Update the records of screen names (and selected layout UUID)
+				// Updates dynamic module vars for stage layouts
+				// Also record UUID of the current_pro7_stage_layout_name for selected watched screen
 				if (objData.hasOwnProperty('stageScreens')) {
+					// Empty old list of pro7StageScreens
 					self.currentState.internal.pro7StageScreens = []
+
+					// Refresh list from new data
+					var updateModuleVars = false
 					objData.stageScreens.forEach(function (stageScreen) {
 						var stageScreenName = stageScreen['stageScreenName']
 						var stageScreenUUID = stageScreen['stageScreenUUID']
@@ -2096,7 +2321,7 @@ instance.prototype.onWebSocketMessage = function (message) {
 							layoutUUID: stageLayoutSelectedLayoutUUID,
 						})
 
-						// Update record of layout name for this pro7 stage screen
+						// Update dynamic module var with current layout name for this pro7 stage screen
 						try {
 							self.currentState.dynamicVariables[stageScreenName + '_pro7_stagelayoutname'] =
 								self.currentState.internal.pro7StageLayouts.find(
@@ -2106,6 +2331,12 @@ instance.prototype.onWebSocketMessage = function (message) {
 								stageScreenName + '_pro7_stagelayoutname',
 								self.currentState.dynamicVariables[stageScreenName + '_pro7_stagelayoutname']
 							)
+							// If we don't already have this dynamic var defined then add a definition for it (we'll update Companion once loop is done)
+							var varDef = { label: stageScreenName + '_pro7_stagelayoutname', name: stageScreenName + '_pro7_stagelayoutname'}
+							if (!self.currentState.dynamicVariablesDefs.some(({name}) => name === varDef.name)) {
+								self.currentState.dynamicVariablesDefs.push(varDef)
+								updateModuleVars = true
+							}
 						} catch (e) {
 							self.log(
 								'warn',
@@ -2124,6 +2355,11 @@ instance.prototype.onWebSocketMessage = function (message) {
 							self.checkFeedbacks('stagedisplay_active')
 						}
 					})
+					
+					// Tell Companion about any new module vars for stage screens that were added (so they become visible in WebUI etc)
+					if (updateModuleVars) {
+						self.setVariableDefinitions(self.currentState.dynamicVariablesDefs)
+					}
 				}
 
 				// Update current_pro7_stage_layout_name

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 		"propresenter6",
 		"propresenter"
 	],
-	"version": "2.4.1",
+	"version": "2.4.2",
 	"api_version": "1.0.0",
 	"keywords": [
 		"Software",


### PR DESCRIPTION
Tested on Pro 7.8.* on MacOS and Windows

Allow hostname (or IP)
Add module var "current_presentation_path".
Full support for dynamically added module vars for all stage screens and clocks (now show in Ui and can be used in triggers etc).
Fixed issue with follower beta feature not properly tracking when disconnected and causing issues.
Allow variables to be used in the "Specific Slide" action paremeters - This comes in handy if you store current_slide and current_present_path in custom vars and later use those custom vars as paremeters to recall the stored slide
Add follwing BETA actions using new Network Link API:
    Specific Slide (Network Link - Beta) - Trigger and slide by name
    Prop Trigger (Network Link - Beta) - Trigger any Prop by name
    Prop Clear (Network Link - Beta) - Clear any specific Prop by name
    Message Clear (Network Link - Beta) - Clear any specifc Message by name
    Trigger Media (Network Link - Beta) - Trigger any Media by name
    Trigger Audio (Network Link - Beta) - Trigger any Audio by name
    Trigger Video Input (Network Link - Beta) - Trigger any Video Input by name
    Custom Action (Network Link - Beta) - Send custom JSON to custom Endpoint Path