### PR TITLE
2.5.2

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -214,6 +214,8 @@ $(propresenter:pro7_clock_n) | hh:mm:ss for clock with index n
 $(propresenter:pro7_clock_n_hourless) | mm:ss for clock with index n
 $(propresenter:pro7_clock_n_totalseconds) | total seconds for clock with index n (can use this for feeback - eg update button colour when clock time <0)
 $(propresenter:current_random_number) | Current random number (update to new random number with action "New Random Number")
+$(propresenter:time_since_last_clock_update) | Number of milliseconds since module last heard a clock update message from ProPresenter. Normally sent every 1000ms. If none are received for longer than say 3000 milliseconds, then the connection has probably failed.
+$(propresenter:connection_timer) | Number of seconds that module has been connected to ProPresenter
 
 > You can click the $ symbol in the module list to see the current values of the module variables.
 > ![ModuleVariables.png](documentation/images/ModuleVariables.png)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,13 @@ Please make sure to include the debug log at the time of the issue and version d
 <br><br>
 
 ## 📝 Change Log:
-### v2.5.1 (Companion Beta Build)
+### v2.5.2 (Companion Build 2.2 RC?)
+- (Update) Add module variables: time_since_last_clock_update and connection_timer (Can be used to monitor for connection issues)
+- (Update) Naming update for WatchDogTimer (improve code clarity)
+- (Update) Improved/extra debug logging (esp important for diagnosing user connection issues)
+- (Bugfix) Stop emptying all current state when stage display connection drops (it only manages one var!)
+
+### v2.5.1 (Companion Beta Build 3861)
 - (New) Supports targeting multiple groups in 'Specific Slide In A Group' action.
 - (New) New Action to generate a random number and store in module variable current_random_number.
 - (Update) minor update to tooltip text in some actions

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 See [HELP.md](https://github.com/greyshirtguy/companion-module-renewedvision-propresenter/blob/master/HELP.md) for instructions
 
-## ⚠️ Known Issues (v2.5.1):
-- Pro7 Windows - currentPresentation gives library path instead of playlist path!! This can affect some Pro7 Windows users when using new actions for slide by label and group slide. Need to determine best workaround/bufix.
+## ⚠️ Known Issues (v2.5.2):
+- Pro7 Windows - currentPresentation gives library path instead of playlist path!! This can affect some Pro7 Windows users when using new actions for slide by label and group slide. Need to determine a possible workaround as this will not be fixed upstream in Pro7 due to work on a new replacement API
 
 ## ⚠️ Reporting An Issue:
 All issues/bugs are reported in tracked in the [Issues List](https://github.com/bitfocus/companion-module-renewedvision-propresenter/issues) on the Github repo.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 		"propresenter6",
 		"propresenter"
 	],
-	"version": "2.5.1",
+	"version": "2.5.2",
 	"api_version": "1.0.0",
 	"keywords": [
 		"Software",


### PR DESCRIPTION
v2.5.2
(Update) Add module variables: time_since_last_clock_update and connection_timer (Can be used to monitor for connection issues)
(Update) Naming update for WatchDogTimer (improve code clarity)
(Update) Improved/extra debug logging (esp important for diagnosing user connection issues)
(Bugfix) Stop emptying all current state when stage display connection drops (it only manages one var!)