### PR TITLE
Added MIDI listener

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -39,6 +39,9 @@ If you chose to also enable the stage display app option in ProPresenter prefere
 ![ModuleStageSettings.png](documentation/images/ModuleStageSettings.png)<br>
 > N.B. At the time of writing this module, there is a bug in ProPresenter 6 where if you choose to enter a Port number for the stage display app - it will actually ignore it and use the "main" network port you recorded in step 8 above.
 
+_🎹 Optional MIDI Listener_  
+There is an optional MIDI listener to enable remote control of Companion through MIDI.  If you enable this option, you can send a Note-On message to Companion to cause a remote button press.  The numberical value of the note will specify the page of the button to press and the intensity of the note will specify the button to press on that page.
+
 _**⚠️ Pro7/Windows users ⚠️**  
 Currently there is a noticeable performance impact on Pro7/Windows when companion sends messages to Pro7 to track info about the current presentation. To work around this, there is now a new option called "Send Presentation Info Requests To ProPresenter" in the module configuration where you can optionally turn that off.  Doing so will remove the performance impact (random lag when changing slides) but will stop updating the dynamic variables: remaining_slides, total_slides or presentation_name.  You will no longer be able to display them on buttons.<br>
 However, there is also another option to configure the **type** of the presentation request.  Pro7 users on Windows may find using the "Manual" type works well enough on their system without impacting performance - enabling them to leave the Send Presentation Info Requests To ProPresenter enabled and enjoy the extra dynamic variables it provides._

--- a/index.js
+++ b/index.js
@@ -3125,7 +3125,15 @@ instance.prototype.onFollowerWebSocketMessage = function (message) {
  */
 instance.prototype.onSDWebSocketMessage = function (message) {
 	var self = this
-	var objData = JSON.parse(message)
+	var objData
+	// Try to parse websocket payload as JSON...
+	try {
+		objData = JSON.parse(message)
+	} catch (err) {
+		self.log('warn', err.message)
+		return
+	}
+	
 	switch (objData.acn) {
 		case 'ath':
 			if (objData.ath === true) {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 		"propresenter6",
 		"propresenter"
 	],
-	"version": "2.5.2",
+	"version": "2.5.3",
 	"api_version": "1.0.0",
 	"keywords": [
 		"Software",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,19 +2,51 @@
 # yarn lockfile v1
 
 
+bindings@~1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
+  integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
+  dependencies:
+    file-uri-to-path "1.0.0"
+
 debug@^2.2.0:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
     ms "2.0.0"
 
+easymidi@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/easymidi/-/easymidi-2.1.0.tgz#8d628109bffad981f843c631e0aa961cb0ed5d9f"
+  integrity sha512-RWhn7AIl0uZLoOTo7wtyLFGQtz9QaLPNyGx9TM2SWqaGlhncGz8XgaiLrbNvNbBiCzO/Kn59mR4yaIGaKdET5A==
+  dependencies:
+    midi "^2.0.0"
+
+file-uri-to-path@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
+  integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
+
 is-typedarray@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
 
+midi@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/midi/-/midi-2.0.0.tgz#5035dd0d0c4b381eeb6e9202c785ce81221d0c7a"
+  integrity sha512-HyCLWa+ET8Aqfu/NxdNkxfCx0EfCJrcZgKuhrY4c9UgkfxRt3ChM7RP1oC5vJf7ALXyuAG47jqr5yUlvSodTPQ==
+  dependencies:
+    bindings "~1.5.0"
+    nan "^2.14.2"
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+
+nan@^2.14.2:
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.15.0.tgz#3f34a473ff18e15c1b5626b62903b5ad6e665fee"
+  integrity sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==
 
 nan@^2.3.3:
   version "2.10.0"


### PR DESCRIPTION
Added MIDI listener to module enable Companion button press.
By default it is disabled - you need to enabled in module config.
It allows you to send MIDI (Note-On) messages from ProPresenter to Companipn (this module) and it will press a Companion button where the Note-On value => Index of Page and the Note-On Intensity => Index of Button to press